### PR TITLE
[Feat] 결제 정보 생성 #17

### DIFF
--- a/src/main/java/com/gamja/tiggle/common/BaseResponse.java
+++ b/src/main/java/com/gamja/tiggle/common/BaseResponse.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import static org.example.tiggle.common.BaseResponseStatus.SUCCESS;
+import static com.gamja.tiggle.common.BaseResponseStatus.SUCCESS;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/gamja/tiggle/payment/adapter/in/web/CreatePaymentController.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/in/web/CreatePaymentController.java
@@ -1,0 +1,63 @@
+package com.gamja.tiggle.payment.adapter.in.web;
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.payment.application.port.in.CreatePaymentUseCase;
+import lombok.RequiredArgsConstructor;
+import com.gamja.tiggle.common.BaseResponse;
+import com.gamja.tiggle.common.BaseResponseStatus;
+import com.gamja.tiggle.payment.adapter.in.web.request.CreatePaymentRequest;
+import com.gamja.tiggle.payment.application.port.in.CreatePaymentCommand;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/payment")
+@RequiredArgsConstructor
+public class CreatePaymentController {
+    private final CreatePaymentUseCase createPaymentUseCase;
+    //private final PaymentPersistenceOutputAdapter;
+
+    @PostMapping
+    BaseResponse create(@RequestBody CreatePaymentRequest request) { //, @AuthenticationPrincipal CustomUserDetails customUserDetails)
+        Boolean requestChk = true;
+        //CustomUserDetails를 확인하여 로그인한 사용자의 정보와 Role을 확인
+//        if (customUserDetails != null) {
+//            user = customUserDetails.getUser();
+//            if (request.getAgree) {
+//                    if ((request.getReservationId() != null)||(user.getRole().equals("ROLE_USER"))) {
+//                        if((request.getTicketPrice()<=0)||(request.getFee()<0)||(request.getUsePoint()<0)) {
+//                            return new BaseException(BaseResponseStatus.잘못된 결제 정보);
+//                        }
+//                        else requestChk =true;
+//                    }
+//                    else {
+//                        return new BaseException(BaseResponseStatus.비 정상적인 접근);
+//                    }
+//            }
+//        }
+//        else {
+//            return new BaseException(BaseResponseStatus.수수료 동의 안함);
+//        }
+
+        if (requestChk == true) {
+            CreatePaymentCommand command = CreatePaymentCommand.builder()
+                    //.username(user.getName())
+                    .reservationId(request.getReservationId())
+                    .ticketPrice(request.getTicketPrice())
+                    .usePoint(request.getUsePoint())
+                    .string(request.getPayType())
+                    .fee(request.getFee())
+                    .build();
+            try {
+                createPaymentUseCase.save(command);
+            } catch (BaseException e) {
+                return new BaseResponse(e.getStatus());
+            }
+        }
+        return new BaseResponse(BaseResponseStatus.SUCCESS);
+    }
+
+
+}

--- a/src/main/java/com/gamja/tiggle/payment/adapter/in/web/request/CreatePaymentRequest.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/in/web/request/CreatePaymentRequest.java
@@ -1,0 +1,20 @@
+package com.gamja.tiggle.payment.adapter.in.web.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreatePaymentRequest {
+    private Long reservationId;
+    private String payType;
+    private Integer ticketPrice;
+    private Integer usePoint;
+    private Integer fee;
+    private Boolean agree;
+
+}

--- a/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/JpaPaymentRepository.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/JpaPaymentRepository.java
@@ -1,0 +1,6 @@
+package com.gamja.tiggle.payment.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaPaymentRepository extends JpaRepository<PaymentEntity, Long> {
+}

--- a/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentEntity.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentEntity.java
@@ -1,0 +1,49 @@
+package com.gamja.tiggle.payment.adapter.out.persistence;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Date;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+    private Integer ticketPrice;
+    private Integer usePoint;
+    private Integer fee;
+    private String string;
+    private Boolean verify;
+
+    //@ManyToOne
+    //@JoinColumn(name = "user_id")
+    //private User user;
+
+    //@OneToOne
+    //@JoinColumn(name = "reservation_id")
+    //private Reservation reservation;
+
+    @Column(updatable = false, nullable = false)
+    private Date createdAt;
+
+    private Date verifiedAt;
+
+    @PrePersist
+    void createdAt() {
+        this.createdAt = Timestamp.from(Instant.now());
+    }
+
+    @PreUpdate
+    void verifiedAt() {
+        this.verifiedAt = Timestamp.from(Instant.now());
+    }
+
+}

--- a/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentPersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentPersistenceAdapter.java
@@ -1,0 +1,38 @@
+package com.gamja.tiggle.payment.adapter.out.persistence;
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.payment.application.port.out.PaymentPersistencePort;
+import com.gamja.tiggle.payment.domain.Payment;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentPersistenceAdapter implements PaymentPersistencePort {
+    private final JpaPaymentRepository jpaPaymentRepository;
+    //private final JpaReservationRepository jpaReservationRepository;
+
+    @Override
+    public void savePayment(Payment payment) throws BaseException {
+        //ReservationEntity result = jpaReservationRepository.findById(payment.getReservationId())
+        //if (!(result.getState)) {
+        PaymentEntity entity = PaymentEntity.builder()
+                .username(payment.getUsername())
+                .ticketPrice(payment.getTicketPrice())
+                .usePoint(payment.getUsePoint())
+                .fee(payment.getFee())
+                .string(payment.getString())
+                .verify(payment.getVerify())
+                //.reservation(result)
+                .build();
+
+        entity.createdAt();
+        jpaPaymentRepository.save(entity);
+        //}
+//        else{
+//            throw BaseException(BaseResponseStatus.이미 결제된 티켓);
+//        }
+
+    }
+}
+

--- a/src/main/java/com/gamja/tiggle/payment/application/port/in/CreatePaymentCommand.java
+++ b/src/main/java/com/gamja/tiggle/payment/application/port/in/CreatePaymentCommand.java
@@ -1,0 +1,17 @@
+package com.gamja.tiggle.payment.application.port.in;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreatePaymentCommand {
+    private Long reservationId;
+    private String username;
+    private Integer ticketPrice;
+    private Integer usePoint;
+    private Integer fee;
+    private String string;
+    private Boolean verify;
+}
+

--- a/src/main/java/com/gamja/tiggle/payment/application/port/in/CreatePaymentUseCase.java
+++ b/src/main/java/com/gamja/tiggle/payment/application/port/in/CreatePaymentUseCase.java
@@ -1,0 +1,9 @@
+package com.gamja.tiggle.payment.application.port.in;
+
+import com.gamja.tiggle.common.BaseException;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface CreatePaymentUseCase {
+    void save(CreatePaymentCommand command) throws BaseException;
+}

--- a/src/main/java/com/gamja/tiggle/payment/application/port/out/PaymentPersistencePort.java
+++ b/src/main/java/com/gamja/tiggle/payment/application/port/out/PaymentPersistencePort.java
@@ -1,0 +1,8 @@
+package com.gamja.tiggle.payment.application.port.out;
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.payment.domain.Payment;
+
+public interface PaymentPersistencePort {
+    void savePayment(Payment payment) throws BaseException;
+}

--- a/src/main/java/com/gamja/tiggle/payment/application/service/CreatePaymentService.java
+++ b/src/main/java/com/gamja/tiggle/payment/application/service/CreatePaymentService.java
@@ -1,0 +1,29 @@
+package com.gamja.tiggle.payment.application.service;
+
+import com.gamja.tiggle.common.BaseException;
+import lombok.RequiredArgsConstructor;
+import com.gamja.tiggle.payment.application.port.in.CreatePaymentCommand;
+import com.gamja.tiggle.payment.application.port.in.CreatePaymentUseCase;
+import com.gamja.tiggle.payment.application.port.out.PaymentPersistencePort;
+import com.gamja.tiggle.payment.domain.Payment;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CreatePaymentService implements CreatePaymentUseCase {
+    private final PaymentPersistencePort paymentPersistencePort;
+
+    @Override
+    public void save(CreatePaymentCommand command) throws BaseException {
+        Payment payment = Payment.builder()
+                .reservationId(command.getReservationId())
+                .username(command.getUsername())
+                .ticketPrice(command.getTicketPrice())
+                .usePoint(command.getUsePoint())
+                .fee(command.getFee())
+                .string(command.getString())
+                .verify(false)
+                .build();
+        paymentPersistencePort.savePayment(payment);
+    }
+}

--- a/src/main/java/com/gamja/tiggle/payment/domain/Payment.java
+++ b/src/main/java/com/gamja/tiggle/payment/domain/Payment.java
@@ -1,0 +1,26 @@
+package com.gamja.tiggle.payment.domain;
+
+import lombok.AllArgsConstructor;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Payment {
+    private Long reservationId;
+    private String username;
+    private Integer ticketPrice;
+    private Integer usePoint;
+    private Integer fee;
+    private String string;
+    private Boolean verify;
+    private Date createdAt;
+    private Date verifiedAt;
+}
+


### PR DESCRIPTION
## 연관된 이슈
#17
<br>

## 작업 내용
결제 파트의 기본적인  Hexagonal architecture 구현
사용자의 요청을 받아 결제 엔티티로 변환하여 DB에 저장
User, Reservation의 관계를 가진 데이터를 받아올 때 발생할 수 있는 예외 들을 컨트롤러에서 처리 
<br> 

## 전달 사항
BaseResponseStatus의 내용이 없어 연관관계를 가지는 데이터 및 예외 처리는 주석 처리함.