### PR TITLE
[Feat] 조회한 공연의 날짜 및 회차 정보 조회

### DIFF
--- a/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
+++ b/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
@@ -8,17 +8,41 @@ import lombok.Getter;
 @Getter
 public enum BaseResponseStatus {
 
-    FAIL(false,500,"요청 실패"),
+    FAIL(false, 500, "요청 실패"),
 
 
     /**
      * 1000 : 요청 성공
      */
-    SUCCESS(true, 1000, "요청에 성공하였습니다.");
+    SUCCESS(true, 1000, "요청에 성공하였습니다."),
+
+    /**
+     * 2000: 유저
+     */
+
+    /**
+     * 3000: 프로그램
+     */
+
+    NOT_FOUND_PROGRAM(false, 3100, "프로그램이 존재하지 않습니다.");
+
+    /**
+     * 4000: 결제
+     */
+
+    /**
+     * 5000: 예매
+     */
+
+    /**
+     * 6000: 교환
+     */
+
 
     private final boolean isSuccess;
     private final int code;
     private final String message;
+
 
     private BaseResponseStatus(boolean isSuccess, int code, String message) {
         this.isSuccess = isSuccess;

--- a/src/main/java/com/gamja/tiggle/program/adapter/out/persistence/ProgramPersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/program/adapter/out/persistence/ProgramPersistenceAdapter.java
@@ -4,6 +4,7 @@ import com.gamja.tiggle.category.adapter.out.persistence.CategoryEntity;
 import com.gamja.tiggle.category.adapter.out.persistence.JpaCategoryRepository;
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.common.BaseResponseStatus;
+import com.gamja.tiggle.program.application.port.out.ProgramPort;
 import lombok.RequiredArgsConstructor;
 import com.gamja.tiggle.common.annotation.PersistenceAdapter;
 import com.gamja.tiggle.program.application.port.out.CreateProgramPort;
@@ -11,7 +12,7 @@ import com.gamja.tiggle.program.domain.Program;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class ProgramPersistenceAdapter implements CreateProgramPort {
+public class ProgramPersistenceAdapter implements CreateProgramPort, ProgramPort {
     private final JpaProgramRepository jpaProgramRepository;
     private final JpaProgramImageRepository jpaProgramImageRepository;
     private final JpaCategoryRepository jpaCategoryRepository;
@@ -42,4 +43,8 @@ public class ProgramPersistenceAdapter implements CreateProgramPort {
 
     }
 
+    @Override
+    public boolean existProgram(Long id) {
+        return jpaProgramRepository.existsById(id);
+    }
 }

--- a/src/main/java/com/gamja/tiggle/program/application/port/out/ProgramPort.java
+++ b/src/main/java/com/gamja/tiggle/program/application/port/out/ProgramPort.java
@@ -1,0 +1,5 @@
+package com.gamja.tiggle.program.application.port.out;
+
+public interface ProgramPort {
+    boolean existProgram(Long id);
+}

--- a/src/main/java/com/gamja/tiggle/program/domain/Program.java
+++ b/src/main/java/com/gamja/tiggle/program/domain/Program.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 @Builder
 @Getter
-public class Program extends BaseEntity {
+public class Program{
     private Long id;
     private String programName;
     private String programInfo;

--- a/src/main/java/com/gamja/tiggle/program/domain/Program.java
+++ b/src/main/java/com/gamja/tiggle/program/domain/Program.java
@@ -1,17 +1,14 @@
 package com.gamja.tiggle.program.domain;
 
-import com.gamja.tiggle.category.domain.Category;
 import lombok.Builder;
 import lombok.Getter;
-import com.gamja.tiggle.common.BaseEntity;
-import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
 @Getter
-public class Program{
+public class Program {
     private Long id;
     private String programName;
     private String programInfo;

--- a/src/main/java/com/gamja/tiggle/times/adapter/in/web/GetTimesController.java
+++ b/src/main/java/com/gamja/tiggle/times/adapter/in/web/GetTimesController.java
@@ -1,0 +1,44 @@
+package com.gamja.tiggle.times.adapter.in.web;
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.common.BaseResponse;
+import com.gamja.tiggle.common.annotation.WebAdapter;
+import com.gamja.tiggle.times.adapter.in.web.response.GetTimesResponse;
+import com.gamja.tiggle.times.application.port.in.GetTimesUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@WebAdapter
+@RequiredArgsConstructor
+@RequestMapping("/times")
+public class GetTimesController {
+
+    private final GetTimesUseCase getTimesUseCase;
+
+    @GetMapping("/{id}/seq")
+    public BaseResponse<List<GetTimesResponse>> getTimes(@PathVariable Long id)  {
+        List<GetTimesResponse> list = null;
+        try {
+            list = getList(id);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+        return new BaseResponse<>(list);
+    }
+
+    private List<GetTimesResponse> getList(Long id) throws BaseException {
+        return getTimesUseCase.getTimes(id).stream().map(times ->
+                GetTimesResponse.builder()
+                        .id(times.getId())
+                        .date(times.getDate())
+                        .round(times.getRound())
+                        .date(times.getDate())
+                        .limitEndTime(times.getLimitEndTime())
+                        .build()).toList();
+    }
+
+}

--- a/src/main/java/com/gamja/tiggle/times/adapter/in/web/GetTimesController.java
+++ b/src/main/java/com/gamja/tiggle/times/adapter/in/web/GetTimesController.java
@@ -21,7 +21,7 @@ public class GetTimesController {
 
     @GetMapping("/{id}/seq")
     public BaseResponse<List<GetTimesResponse>> getTimes(@PathVariable Long id)  {
-        List<GetTimesResponse> list = null;
+        List<GetTimesResponse> list;
         try {
             list = getList(id);
         } catch (BaseException e) {

--- a/src/main/java/com/gamja/tiggle/times/adapter/in/web/response/GetTimesResponse.java
+++ b/src/main/java/com/gamja/tiggle/times/adapter/in/web/response/GetTimesResponse.java
@@ -1,0 +1,19 @@
+package com.gamja.tiggle.times.adapter.in.web.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetTimesResponse {
+    private Long id;
+    private LocalDateTime date;
+    private int round;
+    private LocalDateTime limitEndTime;
+}

--- a/src/main/java/com/gamja/tiggle/times/adapter/out/persistence/GetTimesAdapter.java
+++ b/src/main/java/com/gamja/tiggle/times/adapter/out/persistence/GetTimesAdapter.java
@@ -1,0 +1,32 @@
+package com.gamja.tiggle.times.adapter.out.persistence;
+
+import com.gamja.tiggle.common.annotation.PersistenceAdapter;
+import com.gamja.tiggle.times.application.port.out.GetTimesPort;
+import com.gamja.tiggle.times.domain.Times;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class GetTimesAdapter implements GetTimesPort {
+
+    private final TimesRepository timesRepository;
+
+    @Override
+    public List<Times> getTimes(Long id) {
+        List<TimesEntity> TimesList = timesRepository.findAllByProgramId(id);
+        return getList(TimesList);
+    }
+
+    private static List<Times> getList(List<TimesEntity> TimesList) {
+        return TimesList.stream().map(timesEntity -> Times.builder()
+                .id(timesEntity.getId())
+                .programId(timesEntity.getProgram().getId())
+                .date(timesEntity.getDate())
+                .limitEndTime(timesEntity.getLimitEnterTime())
+                .round(timesEntity.getRound())
+                .build()
+        ).toList();
+    }
+}

--- a/src/main/java/com/gamja/tiggle/times/adapter/out/persistence/TimesEntity.java
+++ b/src/main/java/com/gamja/tiggle/times/adapter/out/persistence/TimesEntity.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Getter
 @Builder
-@Table(name = "Times")
+@Table(name = "times")
 public class TimesEntity {
 
 

--- a/src/main/java/com/gamja/tiggle/times/adapter/out/persistence/TimesEntity.java
+++ b/src/main/java/com/gamja/tiggle/times/adapter/out/persistence/TimesEntity.java
@@ -1,0 +1,32 @@
+package com.gamja.tiggle.times.adapter.out.persistence;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import com.gamja.tiggle.program.adapter.out.persistence.ProgramEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Builder
+@Table(name = "Times")
+public class TimesEntity {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ProgramEntity program;
+
+    private int round;
+    private LocalDateTime date;
+    private LocalDateTime limitEnterTime;
+
+}

--- a/src/main/java/com/gamja/tiggle/times/adapter/out/persistence/TimesRepository.java
+++ b/src/main/java/com/gamja/tiggle/times/adapter/out/persistence/TimesRepository.java
@@ -1,0 +1,11 @@
+package com.gamja.tiggle.times.adapter.out.persistence;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TimesRepository extends JpaRepository<TimesEntity, Long> {
+
+    List<TimesEntity> findAllByProgramId(Long id);
+}

--- a/src/main/java/com/gamja/tiggle/times/application/port/in/GetTimesUseCase.java
+++ b/src/main/java/com/gamja/tiggle/times/application/port/in/GetTimesUseCase.java
@@ -1,0 +1,10 @@
+package com.gamja.tiggle.times.application.port.in;
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.times.domain.Times;
+
+import java.util.List;
+
+public interface GetTimesUseCase {
+    List<Times> getTimes(Long id) throws BaseException;
+}

--- a/src/main/java/com/gamja/tiggle/times/application/port/out/GetTimesPort.java
+++ b/src/main/java/com/gamja/tiggle/times/application/port/out/GetTimesPort.java
@@ -1,0 +1,10 @@
+package com.gamja.tiggle.times.application.port.out;
+
+import com.gamja.tiggle.times.domain.Times;
+
+import java.util.List;
+
+public interface GetTimesPort {
+
+    List<Times> getTimes(Long id);
+}

--- a/src/main/java/com/gamja/tiggle/times/application/service/GetTimesService.java
+++ b/src/main/java/com/gamja/tiggle/times/application/service/GetTimesService.java
@@ -1,0 +1,43 @@
+package com.gamja.tiggle.times.application.service;
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.common.BaseResponseStatus;
+import com.gamja.tiggle.common.annotation.UseCase;
+import com.gamja.tiggle.program.application.port.out.ProgramPort;
+import com.gamja.tiggle.times.application.port.in.GetTimesUseCase;
+import com.gamja.tiggle.times.application.port.out.GetTimesPort;
+import com.gamja.tiggle.times.domain.Times;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetTimesService implements GetTimesUseCase {
+
+    private final GetTimesPort getTimesPort;
+    private final ProgramPort programPort;
+
+    @Override
+    public List<Times> getTimes(Long id) throws BaseException {
+        if (programPort.existProgram(id)) {
+            List<Times> times = getTimesPort.getTimes(id);
+            return getList(times);
+        } else {
+            throw new BaseException(BaseResponseStatus.NOT_FOUND_PROGRAM);
+        }
+
+
+    }
+
+    private static List<Times> getList(List<Times> times) {
+        return times.stream().map(t ->
+                Times.builder()
+                        .id(t.getId())
+                        .date(t.getDate())
+                        .limitEndTime(t.getLimitEndTime())
+                        .round(t.getRound())
+                        .build()
+        ).toList();
+    }
+}

--- a/src/main/java/com/gamja/tiggle/times/domain/Times.java
+++ b/src/main/java/com/gamja/tiggle/times/domain/Times.java
@@ -1,0 +1,18 @@
+package com.gamja.tiggle.times.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class Times {
+
+    private Long id;
+    private Long programId;
+    private LocalDateTime date;
+    private int round;
+    private LocalDateTime limitEndTime;
+
+}

--- a/src/main/java/com/gamja/tiggle/times/domain/type/ReservationType.java
+++ b/src/main/java/com/gamja/tiggle/times/domain/type/ReservationType.java
@@ -1,0 +1,7 @@
+package com.gamja.tiggle.times.domain.type;
+
+public enum ReservationType {
+    PENDING,  // 예약 전
+    IN_PROGRESS,  // 예약 중
+    COMPLETED  // 예약 완료
+}


### PR DESCRIPTION
## 연관된 이슈
#5 

<br>

## 작업 내용
조회한 공연의 날짜 및 회차 정보를 조회합니다.
존재하지 않는 공연을 조회하면 NOT_FOUND_PROGRAM 예외 반환
- GetTimesResponse class 
```
Long id
LocalDateTime date
int round
LocalDateTime limitEndTime
```
객체를 리스트로 담아 반환


<br> 

## 전달 사항
