### PR TITLE
[Feat] 예약 가능 좌석 조회 #6

### DIFF
--- a/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentEntity.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentEntity.java
@@ -1,12 +1,15 @@
 package com.gamja.tiggle.payment.adapter.out.persistence;
 
-import com.gamja.tiggle.reservation.adapter.out.persistence.ReservationEntity;
+import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.ReservationEntity;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Date;
-import com.gamja.tiggle.reservation.domain.Reservation;
 
 @Entity
 @Getter

--- a/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentPersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentPersistenceAdapter.java
@@ -3,11 +3,8 @@ package com.gamja.tiggle.payment.adapter.out.persistence;
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.payment.application.port.out.PaymentPersistencePort;
 import com.gamja.tiggle.payment.domain.Payment;
-import com.gamja.tiggle.reservation.adapter.out.persistence.ReservationEntity;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
-import java.util.Date;
 
 @Component
 @RequiredArgsConstructor
@@ -51,8 +48,7 @@ public class PaymentPersistenceAdapter implements PaymentPersistencePort {
                     .createdAt(result.getCreatedAt())
                     .verifiedAt(result.getVerifiedAt())
                     .build();
-        }
-        else {
+        } else {
             //throw BaseException(BaseResponseStatus.잘못된 티켓);
         }
         return null;

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSeatController.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSeatController.java
@@ -1,0 +1,58 @@
+package com.gamja.tiggle.reservation.adapter.in.web;
+
+
+import com.gamja.tiggle.common.BaseResponse;
+import com.gamja.tiggle.common.annotation.WebAdapter;
+import com.gamja.tiggle.reservation.adapter.in.web.request.GetRemainedSeatRequest;
+import com.gamja.tiggle.reservation.adapter.in.web.response.GetRemainedSeatResponse;
+import com.gamja.tiggle.reservation.application.port.in.GetRemainedSeatCommand;
+import com.gamja.tiggle.reservation.application.port.in.GetRemainedSeatUseCase;
+import com.gamja.tiggle.reservation.domain.Seat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+
+@WebAdapter
+@RequiredArgsConstructor
+@RequestMapping("/seat")
+public class GetSeatController {
+
+    private final GetRemainedSeatUseCase getRemainedSeatUseCase;
+
+
+    //@AuthenticationPrincipal CustomUserDetails customUserDetails
+    @PostMapping
+    public BaseResponse<List<GetRemainedSeatResponse>> getRemainedSeat(
+            @RequestBody GetRemainedSeatRequest request) {
+
+        GetRemainedSeatCommand command = toCommand(request);
+
+        List<GetRemainedSeatResponse> list
+                = getRemainedSeatUseCase.getRemainedSeat(command).stream().map(seat ->
+                getResponse(seat)
+        ).toList();
+
+        return new BaseResponse<>(list);
+    }
+
+    private static GetRemainedSeatResponse getResponse(Seat seat) {
+        return GetRemainedSeatResponse.builder()
+                .seatId(seat.getId())
+                .seatNumber(seat.getSeatNumber())
+                .sectionId(seat.getSectionId())
+                .build();
+    }
+
+
+    private static GetRemainedSeatCommand toCommand(GetRemainedSeatRequest request) {
+        return GetRemainedSeatCommand
+                .builder()
+                .programId(request.getProgramId())
+                .timesId(request.getTimesId())
+                .sectionId(request.getSectionId())
+                .build();
+    }
+}

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSectionController.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSectionController.java
@@ -4,7 +4,7 @@ import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.common.BaseResponse;
 import com.gamja.tiggle.common.annotation.WebAdapter;
 import com.gamja.tiggle.reservation.adapter.in.web.response.GetSectionListResponse;
-import com.gamja.tiggle.reservation.application.in.GetSectionUseCase;
+import com.gamja.tiggle.reservation.application.port.in.GetSectionUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetTimesController.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetTimesController.java
@@ -4,7 +4,7 @@ import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.common.BaseResponse;
 import com.gamja.tiggle.common.annotation.WebAdapter;
 import com.gamja.tiggle.reservation.adapter.in.web.response.GetTimesResponse;
-import com.gamja.tiggle.reservation.application.in.GetTimesUseCase;
+import com.gamja.tiggle.reservation.application.port.in.GetTimesUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/request/GetRemainedSeatRequest.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/request/GetRemainedSeatRequest.java
@@ -1,0 +1,13 @@
+package com.gamja.tiggle.reservation.adapter.in.web.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetRemainedSeatRequest {
+
+    private Long programId;
+    private Long timesId;
+    private Long sectionId;
+}

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/GetRemainedSeatResponse.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/GetRemainedSeatResponse.java
@@ -1,0 +1,20 @@
+package com.gamja.tiggle.reservation.adapter.in.web.response;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class GetRemainedSeatResponse {
+
+    private Long seatId;
+    private Long sectionId;
+    private int seatNumber;
+
+    public GetRemainedSeatResponse(Long seatId, Long sectionId, int seatNumber) {
+        this.seatId = seatId;
+        this.sectionId = sectionId;
+        this.seatNumber = seatNumber;
+    }
+}

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/ReservationEntity.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/ReservationEntity.java
@@ -1,4 +1,4 @@
-package com.gamja.tiggle.reservation.adapter.out.persistence;
+package com.gamja.tiggle.reservation.adapter.out.persistence.Entity;
 
 import com.gamja.tiggle.program.adapter.out.persistence.ProgramEntity;
 import com.gamja.tiggle.reservation.domain.type.ReservationType;

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/SeatEntity.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/SeatEntity.java
@@ -1,7 +1,5 @@
-package com.gamja.tiggle.reservation.adapter.out.persistence;
+package com.gamja.tiggle.reservation.adapter.out.persistence.Entity;
 
-import com.gamja.tiggle.program.adapter.out.persistence.GradeEntity;
-import com.gamja.tiggle.program.adapter.out.persistence.LocationEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,6 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Getter
 @Builder
+@Table(name = "seat")
 public class SeatEntity {
 
     @Id
@@ -20,10 +19,7 @@ public class SeatEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private LocationEntity location;
+    private SectionEntity section;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    private GradeEntity grade;
-    private String section;
     private int seatNumber;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/SectionEntity.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/SectionEntity.java
@@ -1,4 +1,4 @@
-package com.gamja.tiggle.reservation.adapter.out.persistence;
+package com.gamja.tiggle.reservation.adapter.out.persistence.Entity;
 
 import com.gamja.tiggle.program.adapter.out.persistence.GradeEntity;
 import com.gamja.tiggle.program.adapter.out.persistence.LocationEntity;

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/TimesEntity.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/TimesEntity.java
@@ -1,4 +1,4 @@
-package com.gamja.tiggle.reservation.adapter.out.persistence;
+package com.gamja.tiggle.reservation.adapter.out.persistence.Entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSectionAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSectionAdapter.java
@@ -3,7 +3,9 @@ package com.gamja.tiggle.reservation.adapter.out.persistence;
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.common.BaseResponseStatus;
 import com.gamja.tiggle.common.annotation.PersistenceAdapter;
-import com.gamja.tiggle.reservation.application.out.GetSectionPort;
+import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.SectionEntity;
+import com.gamja.tiggle.reservation.adapter.out.persistence.repositroy.SectionRepository;
+import com.gamja.tiggle.reservation.application.port.out.GetSectionPort;
 import com.gamja.tiggle.reservation.domain.Section;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetTimesAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetTimesAdapter.java
@@ -1,7 +1,9 @@
 package com.gamja.tiggle.reservation.adapter.out.persistence;
 
 import com.gamja.tiggle.common.annotation.PersistenceAdapter;
-import com.gamja.tiggle.reservation.application.out.GetTimesPort;
+import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.TimesEntity;
+import com.gamja.tiggle.reservation.adapter.out.persistence.repositroy.TimesRepository;
+import com.gamja.tiggle.reservation.application.port.out.GetTimesPort;
 import com.gamja.tiggle.reservation.domain.Times;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/getRemainedSeatAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/getRemainedSeatAdapter.java
@@ -1,0 +1,30 @@
+package com.gamja.tiggle.reservation.adapter.out.persistence;
+
+import com.gamja.tiggle.common.annotation.PersistenceAdapter;
+import com.gamja.tiggle.reservation.adapter.out.persistence.repositroy.SeatRepository;
+import com.gamja.tiggle.reservation.application.port.out.GetRemainedSeatPort;
+import com.gamja.tiggle.reservation.domain.Seat;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@PersistenceAdapter
+@RequiredArgsConstructor
+public class getRemainedSeatAdapter implements GetRemainedSeatPort {
+
+    private final SeatRepository seatRepository;
+
+    @Override
+    public List<Seat> getRemainedSeat(Long programId, Long timesId, Long sectionId) {
+        return getSeats(programId, timesId, sectionId);
+    }
+
+    private List<Seat> getSeats(Long programId, Long timesId, Long sectionId) {
+        return seatRepository.findAvailableSeat(programId, timesId, sectionId).stream().map(getRemainedSeatResponse ->
+                Seat.builder()
+                        .id(getRemainedSeatResponse.getSeatId())
+                        .seatNumber(getRemainedSeatResponse.getSeatNumber())
+                        .sectionId(getRemainedSeatResponse.getSectionId())
+                        .build()).toList();
+    }
+}

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/ReservationRepository.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/ReservationRepository.java
@@ -1,0 +1,11 @@
+package com.gamja.tiggle.reservation.adapter.out.persistence.repositroy;
+
+import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.ReservationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReservationRepository extends JpaRepository<ReservationEntity, Long> {
+
+
+}

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/SeatRepository.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/SeatRepository.java
@@ -1,0 +1,23 @@
+package com.gamja.tiggle.reservation.adapter.out.persistence.repositroy;
+
+import com.gamja.tiggle.reservation.adapter.in.web.response.GetRemainedSeatResponse;
+import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.SeatEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface SeatRepository extends JpaRepository<SeatEntity, Long> {
+
+    @Query("SELECT new com.gamja.tiggle.reservation.adapter.in.web.response.GetRemainedSeatResponse(s.id, s.section.id, s.seatNumber) " +
+            "FROM SeatEntity s " +
+            "LEFT JOIN ReservationEntity r ON s.id = r.seat.id " +
+            "AND r.program.id = :programId " +
+            "AND r.times.id = :timesId " +
+            "WHERE s.section.id = :sectionId " +
+            "AND (r.status IS NULL OR r.status = 'AVAILABLE' OR r.status = 'REFUNDED')")
+    List<GetRemainedSeatResponse> findAvailableSeat(@Param("programId") Long programId,
+                                                    @Param("timesId") Long timesId,
+                                                    @Param("sectionId") Long sectionId);
+}

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/SectionRepository.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/SectionRepository.java
@@ -1,5 +1,6 @@
-package com.gamja.tiggle.reservation.adapter.out.persistence;
+package com.gamja.tiggle.reservation.adapter.out.persistence.repositroy;
 
+import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.SectionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/TimesRepository.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/TimesRepository.java
@@ -1,6 +1,7 @@
-package com.gamja.tiggle.reservation.adapter.out.persistence;
+package com.gamja.tiggle.reservation.adapter.out.persistence.repositroy;
 
 
+import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.TimesEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetRemainedSeatCommand.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetRemainedSeatCommand.java
@@ -1,0 +1,14 @@
+package com.gamja.tiggle.reservation.application.port.in;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetRemainedSeatCommand {
+
+    private Long programId;
+    private Long timesId;
+    private Long sectionId;
+}

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetRemainedSeatUseCase.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetRemainedSeatUseCase.java
@@ -1,0 +1,9 @@
+package com.gamja.tiggle.reservation.application.port.in;
+
+import com.gamja.tiggle.reservation.domain.Seat;
+
+import java.util.List;
+
+public interface GetRemainedSeatUseCase {
+    List<Seat> getRemainedSeat(GetRemainedSeatCommand command);
+}

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetSectionUseCase.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetSectionUseCase.java
@@ -1,4 +1,4 @@
-package com.gamja.tiggle.reservation.application.in;
+package com.gamja.tiggle.reservation.application.port.in;
 
 
 import com.gamja.tiggle.common.BaseException;

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetTimesUseCase.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetTimesUseCase.java
@@ -1,4 +1,4 @@
-package com.gamja.tiggle.reservation.application.in;
+package com.gamja.tiggle.reservation.application.port.in;
 
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.reservation.domain.Times;

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetRemainedSeatPort.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetRemainedSeatPort.java
@@ -1,0 +1,9 @@
+package com.gamja.tiggle.reservation.application.port.out;
+
+import com.gamja.tiggle.reservation.domain.Seat;
+
+import java.util.List;
+
+public interface GetRemainedSeatPort {
+    List<Seat> getRemainedSeat(Long programId, Long timesId, Long sectionId);
+}

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSectionPort.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSectionPort.java
@@ -1,4 +1,4 @@
-package com.gamja.tiggle.reservation.application.out;
+package com.gamja.tiggle.reservation.application.port.out;
 
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.reservation.domain.Section;

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetTimesPort.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetTimesPort.java
@@ -1,4 +1,4 @@
-package com.gamja.tiggle.reservation.application.out;
+package com.gamja.tiggle.reservation.application.port.out;
 
 import com.gamja.tiggle.reservation.domain.Times;
 

--- a/src/main/java/com/gamja/tiggle/reservation/application/service/GetRemainedSeatService.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/service/GetRemainedSeatService.java
@@ -1,0 +1,24 @@
+package com.gamja.tiggle.reservation.application.service;
+
+import com.gamja.tiggle.common.annotation.UseCase;
+import com.gamja.tiggle.reservation.application.port.in.GetRemainedSeatCommand;
+import com.gamja.tiggle.reservation.application.port.in.GetRemainedSeatUseCase;
+import com.gamja.tiggle.reservation.application.port.out.GetRemainedSeatPort;
+import com.gamja.tiggle.reservation.domain.Seat;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@UseCase
+@RequiredArgsConstructor
+public class GetRemainedSeatService implements GetRemainedSeatUseCase {
+    private final GetRemainedSeatPort getRemainedSeatPort;
+
+    @Override
+    public List<Seat> getRemainedSeat(GetRemainedSeatCommand command) {
+        return getRemainedSeatPort.getRemainedSeat(command.getProgramId(),
+                command.getTimesId(),
+                command.getSectionId());
+
+    }
+}

--- a/src/main/java/com/gamja/tiggle/reservation/application/service/GetSectionService.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/service/GetSectionService.java
@@ -1,9 +1,9 @@
-package com.gamja.tiggle.reservation.service;
+package com.gamja.tiggle.reservation.application.service;
 
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.common.annotation.UseCase;
-import com.gamja.tiggle.reservation.application.in.GetSectionUseCase;
-import com.gamja.tiggle.reservation.application.out.GetSectionPort;
+import com.gamja.tiggle.reservation.application.port.in.GetSectionUseCase;
+import com.gamja.tiggle.reservation.application.port.out.GetSectionPort;
 import com.gamja.tiggle.reservation.domain.Section;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/gamja/tiggle/reservation/application/service/GetTimesService.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/service/GetTimesService.java
@@ -1,11 +1,11 @@
-package com.gamja.tiggle.reservation.service;
+package com.gamja.tiggle.reservation.application.service;
 
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.common.BaseResponseStatus;
 import com.gamja.tiggle.common.annotation.UseCase;
 import com.gamja.tiggle.program.application.port.out.ProgramPort;
-import com.gamja.tiggle.reservation.application.in.GetTimesUseCase;
-import com.gamja.tiggle.reservation.application.out.GetTimesPort;
+import com.gamja.tiggle.reservation.application.port.in.GetTimesUseCase;
+import com.gamja.tiggle.reservation.application.port.out.GetTimesPort;
 import com.gamja.tiggle.reservation.domain.Times;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/gamja/tiggle/reservation/domain/Seat.java
+++ b/src/main/java/com/gamja/tiggle/reservation/domain/Seat.java
@@ -11,6 +11,6 @@ public class Seat {
     private Long id;
     private Location location;
     private Grade grade;
-    private String section;
+    private Long sectionId;
     private int seatNumber;
 }


### PR DESCRIPTION
## 연관된 이슈
#6 
<br>

## 작업 내용
JPQL로 예약 가능 좌석 조회
예약 가능한 죄석은 예약이 존재하지 않거나, 상태가 AVAILABLE이거나 환불된 좌석
<br> 

## 전달 사항
추후에 회차-좌석 테이블을 따로 구현해서 좌석별 예약 상태 관리를 좀 더 용이하게 할 필요가 있음 
