### PR TITLE
[Feat] 결제 서비스 reservation 연동

### DIFF
--- a/src/main/java/com/gamja/tiggle/payment/adapter/in/web/CreatePaymentController.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/in/web/CreatePaymentController.java
@@ -46,7 +46,7 @@ public class CreatePaymentController {
                     .reservationId(request.getReservationId())
                     .ticketPrice(request.getTicketPrice())
                     .usePoint(request.getUsePoint())
-                    .string(request.getPayType())
+                    .payType(request.getPayType())
                     .fee(request.getFee())
                     .build();
             try {

--- a/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/JpaPaymentRepository.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/JpaPaymentRepository.java
@@ -1,7 +1,8 @@
 package com.gamja.tiggle.payment.adapter.out.persistence;
 
+import com.gamja.tiggle.reservation.adapter.out.persistence.ReservationEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaPaymentRepository extends JpaRepository<PaymentEntity, Long> {
-    PaymentEntity findByReservationId(Long id);
+    PaymentEntity findByReservationEntity_Id(Long id);
 }

--- a/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentEntity.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentEntity.java
@@ -6,13 +6,13 @@ import lombok.*;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Date;
-import com.gamja.tiggle.reservation.domain.Reservation;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(name = "payment")
 public class PaymentEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,7 +22,7 @@ public class PaymentEntity {
     private Integer ticketPrice;
     private Integer usePoint;
     private Integer fee;
-    private String string;
+    private String payType;
     private Boolean verify;
 
     //@ManyToOne
@@ -31,7 +31,7 @@ public class PaymentEntity {
 
     @OneToOne
     @JoinColumn(name = "reservation_id")
-    private ReservationEntity reservation;
+    private ReservationEntity reservationEntity;
 
     @Column(updatable = false, nullable = false)
     private Date createdAt;

--- a/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentPersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentPersistenceAdapter.java
@@ -4,29 +4,30 @@ import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.payment.application.port.out.PaymentPersistencePort;
 import com.gamja.tiggle.payment.domain.Payment;
 import com.gamja.tiggle.reservation.adapter.out.persistence.ReservationEntity;
+import com.gamja.tiggle.reservation.adapter.out.persistence.ReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import java.util.Date;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
 public class PaymentPersistenceAdapter implements PaymentPersistencePort {
     private final JpaPaymentRepository jpaPaymentRepository;
-    //private final JpaReservationRepository jpaReservationRepository;
+    private final ReservationRepository jpaReservationRepository;
 
     @Override
     public void savePayment(Payment payment) throws BaseException {
-        //ReservationEntity result = jpaReservationRepository.findById(payment.getReservationId())
+            Optional<ReservationEntity> result = jpaReservationRepository.findById(payment.getReservationId());
         //if (!(result.getState)) {
         PaymentEntity entity = PaymentEntity.builder()
                 .username(payment.getUsername())
                 .ticketPrice(payment.getTicketPrice())
                 .usePoint(payment.getUsePoint())
                 .fee(payment.getFee())
-                .string(payment.getString())
+                .payType(payment.getPayType())
                 .verify(payment.getVerify())
-                //.reservation(result)
+                .reservationEntity(result.get())
                 .build();
 
         entity.createdAt();
@@ -38,15 +39,16 @@ public class PaymentPersistenceAdapter implements PaymentPersistencePort {
     }
 
     @Override
-    public Payment searchPayment(Payment payment) throws BaseException {
-        PaymentEntity result = jpaPaymentRepository.findByReservationId(payment.getReservationId());
+    public Payment searchPayment(Long id) throws BaseException {
+        PaymentEntity result = jpaPaymentRepository.findByReservationEntity_Id(id);
         if (result != null) {
             return Payment.builder()
+                    .reservationId(result.getReservationEntity().getId())
                     .username(result.getUsername())
                     .ticketPrice(result.getTicketPrice())
                     .usePoint(result.getUsePoint())
                     .fee(result.getFee())
-                    .string(result.getString())
+                    .payType(result.getPayType())
                     .verify(result.getVerify())
                     .createdAt(result.getCreatedAt())
                     .verifiedAt(result.getVerifiedAt())
@@ -60,9 +62,15 @@ public class PaymentPersistenceAdapter implements PaymentPersistencePort {
 
     @Override
     public void verify(Payment payment) throws BaseException {
-        PaymentEntity searchedEntity = jpaPaymentRepository.findByReservationId(payment.getReservationId());
+        PaymentEntity searchedEntity = jpaPaymentRepository.findByReservationEntity_Id(payment.getReservationId());
         PaymentEntity entity = PaymentEntity.builder()
                 .id(searchedEntity.getId())
+                .reservationEntity(searchedEntity.getReservationEntity())
+                .username(searchedEntity.getUsername())
+                .ticketPrice(searchedEntity.getTicketPrice())
+                .usePoint(searchedEntity.getUsePoint())
+                .fee(searchedEntity.getFee())
+                .payType(searchedEntity.getPayType())
                 .verify(true)
                 .build();
 

--- a/src/main/java/com/gamja/tiggle/payment/adapter/out/portOne/PortOneAdapter.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/out/portOne/PortOneAdapter.java
@@ -74,10 +74,16 @@ public class PortOneAdapter implements PortOnePort {
         String status = (String) result.get("status");
         String payId = (String) result.get("id");
 
-        Integer canceled = (Integer) amount.get("cancelled");
+        Double D_canceled = (Double) amount.get("cancelled");
 
         String country = (String) result.get("currency");
-        Integer totalPrice = (Integer) amount.get("total");
+        Double D_totalPrice = (Double) amount.get("total");
+
+        int tmp1 = D_canceled.intValue();
+        Integer canceled = Integer.valueOf(tmp1);
+
+        int tmp2 = D_totalPrice.intValue();
+        Integer totalPrice = Integer.valueOf(tmp2);
 
         return VerifyData.builder()
                 .status(status)

--- a/src/main/java/com/gamja/tiggle/payment/adapter/out/portOne/VerifyData.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/out/portOne/VerifyData.java
@@ -12,5 +12,6 @@ public class VerifyData {
     private Integer canceled;
 
     private String country;
+
     private Integer totalPrice;
 }

--- a/src/main/java/com/gamja/tiggle/payment/application/port/in/CreatePaymentCommand.java
+++ b/src/main/java/com/gamja/tiggle/payment/application/port/in/CreatePaymentCommand.java
@@ -11,7 +11,7 @@ public class CreatePaymentCommand {
     private Integer ticketPrice;
     private Integer usePoint;
     private Integer fee;
-    private String string;
+    private String payType;
     private Boolean verify;
 }
 

--- a/src/main/java/com/gamja/tiggle/payment/application/port/out/PaymentPersistencePort.java
+++ b/src/main/java/com/gamja/tiggle/payment/application/port/out/PaymentPersistencePort.java
@@ -6,7 +6,7 @@ import com.gamja.tiggle.payment.domain.Payment;
 public interface PaymentPersistencePort {
     void savePayment(Payment payment) throws BaseException;
 
-    Payment searchPayment(Payment payment) throws BaseException;
+    Payment searchPayment(Long id) throws BaseException;
 
     void verify(Payment payment) throws BaseException;
 }

--- a/src/main/java/com/gamja/tiggle/payment/application/service/CreatePaymentService.java
+++ b/src/main/java/com/gamja/tiggle/payment/application/service/CreatePaymentService.java
@@ -21,7 +21,7 @@ public class CreatePaymentService implements CreatePaymentUseCase {
                 .ticketPrice(command.getTicketPrice())
                 .usePoint(command.getUsePoint())
                 .fee(command.getFee())
-                .string(command.getString())
+                .payType(command.getPayType())
                 .verify(false)
                 .build();
         paymentPersistencePort.savePayment(payment);

--- a/src/main/java/com/gamja/tiggle/payment/application/service/PGPaymentService.java
+++ b/src/main/java/com/gamja/tiggle/payment/application/service/PGPaymentService.java
@@ -29,11 +29,8 @@ public class PGPaymentService implements VerifyPaymentUseCase {
         VerifyData data = portOnePort.findByPaymentId(accessToken, paymentId);
 
         Boolean verified = false;
-        Payment payment = Payment.builder()
-                .reservationId(command.getReservationId())
-                        .build();
-         Payment paymentSearched = paymentPersistencePort.searchPayment(payment);
-         //Reservation reservationSearched = reservationPersistence.searchReservation()
+         Payment paymentSearched = paymentPersistencePort.searchPayment(command.getReservationId());
+         //Reservation reservationSearched = reservationPersistencePort.searchReservation()
 
         // 정상 결제 검증
         if (data.getStatus().equals("PAID")&&data.getPayId().equals(command.getPaymentId())&&data.getCanceled() == 0) {
@@ -52,8 +49,7 @@ public class PGPaymentService implements VerifyPaymentUseCase {
                 else {
                     //throw BaseException(BaseResponseStatus.결제 취소 실패);
                 }
-
-                //throw BaseException(BaseResponseStatus.잘못된 결제 데이터로 결제 진행);
+                //throw BaseException(BaseResponseStatus.잘못된 결제 데이터로 결제 정상 취소);
             }
         }
 

--- a/src/main/java/com/gamja/tiggle/payment/domain/Payment.java
+++ b/src/main/java/com/gamja/tiggle/payment/domain/Payment.java
@@ -18,7 +18,7 @@ public class Payment {
     private Integer ticketPrice;
     private Integer usePoint;
     private Integer fee;
-    private String string;
+    private String payType;
     private Boolean verify;
     private Date createdAt;
     private Date verifiedAt;

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/ReservationRepository.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/ReservationRepository.java
@@ -1,0 +1,8 @@
+package com.gamja.tiggle.reservation.adapter.out.persistence;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReservationRepository extends JpaRepository<ReservationEntity, Long> {
+}


### PR DESCRIPTION
## 연관된 이슈
#35
<br>

## 작업 내용
ReservationEntity와 PaymentEntity의 관계 형성
예시 데이터를 처리할 때, 실제 Reservation에서 조회한 데이터로 결제 서비스 실행
<br> 

## 전달 사항
