### PR TITLE
[Feat] 로그인을 통한 UserDetails 생성 및 JWT Bear 토큰 활용 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation group: 'io.awspring.cloud', name: 'spring-cloud-starter-aws', version: '2.4.2'
     //iamimport => 결제 (비공식 maven)
     implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
+    //security
+    implementation 'org.springframework.boot:spring-boot-starter-security:3.3.1'
     //kafka
     implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'

--- a/src/main/java/com/gamja/tiggle/config/SecurityConfig.java
+++ b/src/main/java/com/gamja/tiggle/config/SecurityConfig.java
@@ -36,10 +36,10 @@ public class SecurityConfig {
                         auth
 //                        .requestMatchers(HttpMethod.GET, "//**", "/admin/**").has("ADMIN")
 //                        .requestMatchers("/test/**", "/mypage").authenticated()
-//                        .requestMatchers("/login", "/member/**", "/kakao/**").permitAll()
+                       .requestMatchers("/login", "/user/**", "/program/**").permitAll()
 //                        .anyRequest().authenticated()
 
-                                .anyRequest().permitAll()
+                                .anyRequest().authenticated()
         );
 
         http.addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class);

--- a/src/main/java/com/gamja/tiggle/config/SecurityConfig.java
+++ b/src/main/java/com/gamja/tiggle/config/SecurityConfig.java
@@ -1,0 +1,65 @@
+package com.gamja.tiggle.config;
+
+
+import com.gamja.tiggle.config.filter.JwtFilter;
+import com.gamja.tiggle.config.filter.LoginFilter;
+import com.gamja.tiggle.utils.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtUtil jwtUtil;
+    private final AuthenticationConfiguration authenticationConfiguration;
+    //private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    //private final OAuth2Service oAuth2Service;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf((auth) -> auth.disable());
+        http.httpBasic((auth) -> auth.disable());
+        http.formLogin((auth) -> auth.disable());
+        http.sessionManagement((auth) -> auth.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        // 특정 페이지를 차단하고 나머지 다 허용 - 블랙리스트
+        // 특정 페이지를 허용하고 나머지 다 차단 - 화이트리스트
+
+        http.authorizeHttpRequests((auth) ->
+                        auth
+//                        .requestMatchers(HttpMethod.GET, "//**", "/admin/**").has("ADMIN")
+//                        .requestMatchers("/test/**", "/mypage").authenticated()
+//                        .requestMatchers("/login", "/member/**", "/kakao/**").permitAll()
+//                        .anyRequest().authenticated()
+
+                                .anyRequest().permitAll()
+        );
+
+        http.addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class);
+        http.addFilterAt(new LoginFilter(jwtUtil, authenticationManager(authenticationConfiguration)), UsernamePasswordAuthenticationFilter.class);
+//        http.oauth2Login((config) -> {
+//            config.successHandler(oAuth2AuthenticationSuccessHandler);
+//            config.userInfoEndpoint((endpoint) -> endpoint.userService(oAuth2Service));
+//        });
+
+        return http.build();
+    }
+
+    @Bean
+    BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+
+        return configuration.getAuthenticationManager();
+    }
+}

--- a/src/main/java/com/gamja/tiggle/config/filter/JwtFilter.java
+++ b/src/main/java/com/gamja/tiggle/config/filter/JwtFilter.java
@@ -50,7 +50,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
         User user = User.builder()
                 .id(id)
-                .email(username)
+                .name(username)
                 .role(role)
                 .build();
 

--- a/src/main/java/com/gamja/tiggle/config/filter/JwtFilter.java
+++ b/src/main/java/com/gamja/tiggle/config/filter/JwtFilter.java
@@ -1,0 +1,68 @@
+package com.gamja.tiggle.config.filter;
+
+
+
+import com.gamja.tiggle.user.domain.CustomUserDetails;
+import com.gamja.tiggle.user.domain.User;
+import com.gamja.tiggle.utils.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+public class JwtFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+
+
+    public JwtFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorization = request.getHeader("Authorization");
+
+        if(authorization == null || !authorization.startsWith("Bearer ")) {
+            System.out.println("Bearer 토큰이 없음");
+            filterChain.doFilter(request, response);
+
+            return;
+        }
+
+        String token = authorization.split(" ")[1];
+
+        if(jwtUtil.isExpired(token)) {
+            System.out.println("토큰 만료됨");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Long id = jwtUtil.getId(token);
+        String username = jwtUtil.getUsername(token);
+        String role = jwtUtil.getRole(token);
+
+
+        User user = User.builder()
+                .id(id)
+                .email(username)
+                .role(role)
+                .build();
+
+        CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+
+        filterChain.doFilter(request,response);
+
+
+    }
+}

--- a/src/main/java/com/gamja/tiggle/config/filter/LoginFilter.java
+++ b/src/main/java/com/gamja/tiggle/config/filter/LoginFilter.java
@@ -1,0 +1,84 @@
+package com.gamja.tiggle.config.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gamja.tiggle.user.adapter.in.web.request.LoginUserRequest;
+import com.gamja.tiggle.user.domain.CustomUserDetails;
+import com.gamja.tiggle.utils.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.*;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+
+
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+    private final JwtUtil jwtUtil;
+    private final AuthenticationManager authenticationManager;
+
+
+    public LoginFilter(JwtUtil jwtUtil, AuthenticationManager authenticationManager) {
+        this.jwtUtil = jwtUtil;
+        this.authenticationManager = authenticationManager;
+    }
+
+    public LoginFilter(AuthenticationManager authenticationManager, JwtUtil jwtUtil, AuthenticationManager authenticationManager1) {
+        super(authenticationManager);
+        this.jwtUtil = jwtUtil;
+        this.authenticationManager = authenticationManager1;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request,
+                                                HttpServletResponse response) throws AuthenticationException {
+        LoginUserRequest loginUserRequest;
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            ServletInputStream inputStream = request.getInputStream();
+            String messageBody = StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+            loginUserRequest = objectMapper.readValue(messageBody, LoginUserRequest.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        String username = loginUserRequest.getEmail();
+        String password = loginUserRequest.getPassword();
+
+        // 그림에서 2번
+        UsernamePasswordAuthenticationToken authToken =
+                new UsernamePasswordAuthenticationToken(username, password, null);
+
+        // 그림에서 3번
+        return authenticationManager.authenticate(authToken);
+    }
+
+    // 그림에서 10번
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request,
+                                            HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
+        CustomUserDetails user = (CustomUserDetails)authResult.getPrincipal();
+
+        Collection<? extends GrantedAuthority> authorities = authResult.getAuthorities();
+        GrantedAuthority auth = authorities.iterator().next();
+        String role = auth.getAuthority();
+        String username = user.getUsername();
+        Long id = user.getUser().getId();
+
+        String token = jwtUtil.createToken(id, username, role);
+
+        response.addHeader("Authorization", "Bearer " + token);
+        PrintWriter out = response.getWriter();
+        out.println("{\"isSuccess\": true, \"accessToken\": \""+token+"\"}");
+    }
+}

--- a/src/main/java/com/gamja/tiggle/payment/adapter/in/web/CreatePaymentController.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/in/web/CreatePaymentController.java
@@ -7,10 +7,12 @@ import com.gamja.tiggle.common.BaseResponse;
 import com.gamja.tiggle.common.BaseResponseStatus;
 import com.gamja.tiggle.payment.adapter.in.web.request.CreatePaymentRequest;
 import com.gamja.tiggle.payment.application.port.in.CreatePaymentCommand;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import com.gamja.tiggle.user.domain.CustomUserDetails;
 
 @RestController
 @RequestMapping("/payment")
@@ -19,7 +21,7 @@ public class CreatePaymentController {
     private final CreatePaymentUseCase createPaymentUseCase;
 
     @PostMapping
-    BaseResponse create(@RequestBody CreatePaymentRequest request) { //, @AuthenticationPrincipal CustomUserDetails customUserDetails)
+    BaseResponse create(@RequestBody CreatePaymentRequest request, @AuthenticationPrincipal CustomUserDetails customUserDetails){
         Boolean requestChk = true;
         //CustomUserDetails를 확인하여 로그인한 사용자의 정보와 Role을 확인
 //        if (customUserDetails != null) {

--- a/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentPersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentPersistenceAdapter.java
@@ -1,6 +1,7 @@
 package com.gamja.tiggle.payment.adapter.out.persistence;
 
 import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.common.BaseResponseStatus;
 import com.gamja.tiggle.payment.application.port.out.PaymentPersistencePort;
 import com.gamja.tiggle.payment.domain.Payment;
 import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.ReservationEntity;
@@ -18,7 +19,9 @@ public class PaymentPersistenceAdapter implements PaymentPersistencePort {
 
     @Override
     public void savePayment(Payment payment) throws BaseException {
-        Optional<ReservationEntity> result = jpaReservationRepository.findById(payment.getReservationId());
+        ReservationEntity result = jpaReservationRepository.findById(payment.getReservationId()).orElseThrow(() ->
+                new BaseException(BaseResponseStatus.BAD_REQUEST)
+                );
         //if (!(result.getState)) {
         PaymentEntity entity = PaymentEntity.builder()
                 .username(payment.getUsername())
@@ -27,7 +30,7 @@ public class PaymentPersistenceAdapter implements PaymentPersistencePort {
                 .fee(payment.getFee())
                 .payType(payment.getPayType())
                 .verify(payment.getVerify())
-                .reservationEntity(result.get())
+                .reservationEntity(result)
                 .build();
 
         entity.createdAt();

--- a/src/main/java/com/gamja/tiggle/user/adapter/in/web/request/LoginUserRequest.java
+++ b/src/main/java/com/gamja/tiggle/user/adapter/in/web/request/LoginUserRequest.java
@@ -1,0 +1,16 @@
+package com.gamja.tiggle.user.adapter.in.web.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginUserRequest {
+    private String email;
+    private String password;
+
+}

--- a/src/main/java/com/gamja/tiggle/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -23,7 +23,7 @@ public class UserPersistenceAdapter implements UserPersistencePort {
                     .name(result.getName())
                     .password(result.getPassword())
                     .loginType(result.getLoginType())
-                    .role("ROLE_USER")
+                    .role("ROLE_MEMBER")
                     .enable(true)
                     .status(result.getStatus())
                     .region_1depth_name(result.getRegion_1depth_name())

--- a/src/main/java/com/gamja/tiggle/user/application/service/CustomUserDetailService.java
+++ b/src/main/java/com/gamja/tiggle/user/application/service/CustomUserDetailService.java
@@ -1,0 +1,36 @@
+package com.gamja.tiggle.user.application.service;
+
+
+import com.gamja.tiggle.user.adapter.out.persistence.JpaUserRepository;
+import com.gamja.tiggle.user.adapter.out.persistence.UserEntity;
+import com.gamja.tiggle.user.domain.CustomUserDetails;
+import com.gamja.tiggle.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+    private final JpaUserRepository jpaUserRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        UserEntity result = jpaUserRepository.findByEmail(username);
+        User user = User.builder()
+                .email(result.getEmail())
+                .password(result.getPassword())
+                .role(result.getRole())
+                .enable(true)
+                .build();
+
+        if (result!=null) {
+            return new CustomUserDetails(user);
+        } else {
+            return null;
+        }
+
+    }
+}

--- a/src/main/java/com/gamja/tiggle/user/application/service/CustomUserDetailService.java
+++ b/src/main/java/com/gamja/tiggle/user/application/service/CustomUserDetailService.java
@@ -20,7 +20,8 @@ public class CustomUserDetailService implements UserDetailsService {
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         UserEntity result = jpaUserRepository.findByEmail(username);
         User user = User.builder()
-                .email(result.getEmail())
+                .id(result.getId())
+                .name(result.getEmail())
                 .password(result.getPassword())
                 .role(result.getRole())
                 .enable(true)

--- a/src/main/java/com/gamja/tiggle/user/application/service/SignupUserService.java
+++ b/src/main/java/com/gamja/tiggle/user/application/service/SignupUserService.java
@@ -8,6 +8,7 @@ import com.gamja.tiggle.user.application.port.out.EmailVerifyPort;
 import com.gamja.tiggle.user.application.port.out.UserPersistencePort;
 import com.gamja.tiggle.user.domain.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Component;
 public class SignupUserService implements SignupUserUseCase {
     private final UserPersistencePort userPersistencePort;
     private final EmailVerifyPort emailVerifyPort;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public String signup(SignupUserCommand command) throws BaseException {
@@ -22,7 +24,7 @@ public class SignupUserService implements SignupUserUseCase {
 
                 .name(command.getName())
                 .email(command.getEmail())
-                .password(command.getPassword())
+                .password(passwordEncoder.encode(command.getPassword()))
                 .loginType(command.getLoginType())
                 .status(command.getStatus())
                 .enable(command.getEnable())

--- a/src/main/java/com/gamja/tiggle/user/domain/CustomUserDetails.java
+++ b/src/main/java/com/gamja/tiggle/user/domain/CustomUserDetails.java
@@ -36,7 +36,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.getEmail();
+        return user.getName();
     }
 
     @Override

--- a/src/main/java/com/gamja/tiggle/user/domain/CustomUserDetails.java
+++ b/src/main/java/com/gamja/tiggle/user/domain/CustomUserDetails.java
@@ -1,0 +1,59 @@
+package com.gamja.tiggle.user.domain;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add(new GrantedAuthority(){
+            @Override
+            public String getAuthority() {
+                return user.getRole();
+            }
+        });
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() { return user.getEnable(); }
+}

--- a/src/main/java/com/gamja/tiggle/utils/JwtUtil.java
+++ b/src/main/java/com/gamja/tiggle/utils/JwtUtil.java
@@ -1,0 +1,52 @@
+package com.gamja.tiggle.utils;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    private SecretKey secretKey;
+
+    public JwtUtil(@Value("${spring.jwt.secret}") String secret) {
+        this.secretKey = new SecretKeySpec(
+                secret.getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS256.key().build().getAlgorithm()
+        );//    HS256 (HMAC + SHA256)
+    }
+
+    public Long getId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("id", Long.class);
+    }
+
+    public String getUsername(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+    }
+
+    public String getRole(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String createToken(Long id, String username, String role) {
+        return Jwts.builder()
+                .claim("id", id)
+                .claim("username", username)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + 60 * 60 * 1000))
+                .signWith(secretKey)
+                .compact();
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
#44 
<br>

## 작업 내용
DB 내 회원  데이터의 ROLE과 enable 데이터를 확인하여 인증된 사용자에게 JWT 토큰 발급
특정 주소로 접속 가능한 ROLE을 제한하고, 토큰을 이용하여 인가 
<br> 

## 전달 사항
http Request/Reponse 방식으로 security Filter에서 예외 처리 필요