### PR TITLE
[Feat] 교환 요청 승인 및 거절 기능 구현 #58

### DIFF
--- a/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
+++ b/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
@@ -18,6 +18,8 @@ public enum BaseResponseStatus {
     SUCCESS(true, 1000, "요청에 성공하였습니다."),
     READ_EXCHANGE_OFFER_SUCCESS(true, 1001, "교환 요청 조회에 성공하였습니다."),
     EXCHANGE_OFFER_SUCCESS(true, 1002, "교환 요청에 성공하였습니다."),
+    EXCHANGE_APPROVAL_SUCCESS(true, 1003, "티켓 교환에 성공하였습니다."),
+    EXCHANGE_REJECT_SUCCESS(true, 1004, "티켓 거절에 성공하였습니다."),
 
 
     /**
@@ -66,6 +68,11 @@ public enum BaseResponseStatus {
     FAIL_LOAD_EXCHANGE_OFFER(false, 6000, "교환 요청 조회에 실패하였습니다."),
     NOT_FOUND_EXCHANGE_OFFER(false, 6001, "일치하는 교환 내역이 존재하지 않습니다."),
     EXIST_EXCHANGE_OFFER(false, 6002, "동일한 요청을 보낼 수 없습니다."),
+    WRONG_USER_EXCHANGE_OFFER(false, 6003, "잘못된 교환 요청입니다."),
+    ALREADY_SUCCESS_EXCHANGE_OFFER(false, 6004, "이미 교환 성공한 요청입니다."),
+    ALREADY_FAIL_EXCHANGE_OFFER(false, 6005, "이미 교환 거절된 요청입니다."),
+    UNAVAILABLE_EXCHANGE_OFFER(false, 6005, "유효하지 않은 교환 요청입니다."),
+
 
 
     /**

--- a/src/main/java/com/gamja/tiggle/exchange/adapter/in/web/CreateExchangeApprovalController.java
+++ b/src/main/java/com/gamja/tiggle/exchange/adapter/in/web/CreateExchangeApprovalController.java
@@ -1,0 +1,73 @@
+package com.gamja.tiggle.exchange.adapter.in.web;
+
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.common.BaseResponse;
+import com.gamja.tiggle.common.BaseResponseStatus;
+import com.gamja.tiggle.common.annotation.WebAdapter;
+import com.gamja.tiggle.exchange.adapter.in.web.request.CreateExchangeApprovalRequest;
+import com.gamja.tiggle.exchange.adapter.out.persistence.ExchangeEntity;
+import com.gamja.tiggle.exchange.application.port.in.CreateExchangeApprovalCommand;
+import com.gamja.tiggle.exchange.application.port.in.CreateExchangeApprovalUseCase;
+import com.gamja.tiggle.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Objects;
+
+@WebAdapter
+@RequiredArgsConstructor
+@RequestMapping("/exchange")
+public class CreateExchangeApprovalController {
+    private final CreateExchangeApprovalUseCase useCase;
+
+    @PostMapping("/approval")
+    public BaseResponse<BaseResponseStatus> createApproval(@RequestBody CreateExchangeApprovalRequest request) {
+        CreateExchangeApprovalCommand command = CreateExchangeApprovalCommand.builder()
+                .exchangeId(request.getExchangeId())
+                .isAgree(request.getIsAgree())
+                .build();
+
+        User user = User.builder().id(1L).build();
+
+        try {
+//            나에게 온 요청이 아닐 때,
+            ExchangeEntity exchangeEntity = useCase.findExchangeEntity(command.getExchangeId());
+
+            if (!Objects.equals(exchangeEntity.getReservation2().getUser().getId(), user.getId())) {
+                throw new BaseException(BaseResponseStatus.WRONG_USER_EXCHANGE_OFFER);
+            }
+
+            if(exchangeEntity.getIsSuccess() == null){
+                command = CreateExchangeApprovalCommand.builder()
+                        .exchangeId(exchangeEntity.getId())
+                        .reservationId1(exchangeEntity.getReservation1().getId())
+                        .reservationId2(exchangeEntity.getReservation2().getId())
+                        .isAgree(request.getIsAgree())
+                        .build();
+
+                if (command.getIsAgree()) {
+                    useCase.create(exchangeEntity, command);
+                } else {
+                    useCase.reject(exchangeEntity);
+                    return new BaseResponse<>(BaseResponseStatus.EXCHANGE_REJECT_SUCCESS);
+                }
+            } else{
+                if (exchangeEntity.getIsSuccess()) {
+                    throw new BaseException(BaseResponseStatus.ALREADY_SUCCESS_EXCHANGE_OFFER);
+                }else  {
+                    throw new BaseException(BaseResponseStatus.ALREADY_FAIL_EXCHANGE_OFFER);
+                }
+            }
+
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+
+        return new BaseResponse<>(BaseResponseStatus.EXCHANGE_APPROVAL_SUCCESS);
+    }
+
+
+}

--- a/src/main/java/com/gamja/tiggle/exchange/adapter/in/web/CreateExchangeOfferController.java
+++ b/src/main/java/com/gamja/tiggle/exchange/adapter/in/web/CreateExchangeOfferController.java
@@ -18,7 +18,7 @@ public class CreateExchangeOfferController {
     private final CreateExchangeOfferUseCase useCase;
 
     @GetMapping("/offer")
-    public BaseResponse createOffer(@RequestParam Long id1 , @RequestParam Long id2) throws BaseException {
+    public BaseResponse<BaseResponseStatus> createOffer(@RequestParam Long id1, @RequestParam Long id2) {
         CreateExchangeOfferCommand command = CreateExchangeOfferCommand.builder()
                 .reservationId1(id1)
                 .reservationId2(id2)
@@ -26,10 +26,10 @@ public class CreateExchangeOfferController {
 
         try {
             useCase.create(command);
-        } catch (BaseException e){
+        } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
         }
 
-        return new BaseResponse(BaseResponseStatus.EXCHANGE_OFFER_SUCCESS);
+        return new BaseResponse<>(BaseResponseStatus.EXCHANGE_OFFER_SUCCESS);
     }
 }

--- a/src/main/java/com/gamja/tiggle/exchange/adapter/in/web/request/CreateExchangeApprovalRequest.java
+++ b/src/main/java/com/gamja/tiggle/exchange/adapter/in/web/request/CreateExchangeApprovalRequest.java
@@ -1,0 +1,12 @@
+package com.gamja.tiggle.exchange.adapter.in.web.request;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CreateExchangeApprovalRequest {
+    private Long exchangeId;
+    private Boolean isAgree;
+}

--- a/src/main/java/com/gamja/tiggle/exchange/adapter/out/persistence/ExchangeEntity.java
+++ b/src/main/java/com/gamja/tiggle/exchange/adapter/out/persistence/ExchangeEntity.java
@@ -29,4 +29,16 @@ public class ExchangeEntity extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation2_id", unique = false)
     private ReservationEntity reservation2;
+
+    public ExchangeEntity watched(){
+        this.isWatch = true;
+
+        return this;
+    }
+
+    public ExchangeEntity successed(Boolean state){
+        this.isSuccess = state;
+
+        return this;
+    }
 }

--- a/src/main/java/com/gamja/tiggle/exchange/adapter/out/persistence/ExchangePersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/exchange/adapter/out/persistence/ExchangePersistenceAdapter.java
@@ -37,7 +37,6 @@ public class ExchangePersistenceAdapter implements ExchangePort {
         ExchangeEntity exchangeEntity = ExchangeEntity.builder()
                 .reservation1(reservation1)
                 .reservation2(reservation2)
-                .isSuccess(exchange.getIsSuccess())
                 .isWatch(exchange.getIsWatch())
                 .build();
 
@@ -48,5 +47,17 @@ public class ExchangePersistenceAdapter implements ExchangePort {
     public Boolean find(CreateExchangeOfferCommand command) {
         ExchangeEntity result = exchangeRepository.findByReservation1IdAndReservation2Id(command.getReservationId1(), command.getReservationId2());
         return result != null;
+    }
+
+    @Override
+    public ExchangeEntity findById(Long id) throws BaseException {
+        return exchangeRepository.findById(id).orElseThrow(() ->
+                new BaseException(BaseResponseStatus.NOT_FOUND_EXCHANGE_OFFER)
+        );
+    }
+
+    @Override
+    public void update(ExchangeEntity exchange) {
+        exchangeRepository.save(exchange);
     }
 }

--- a/src/main/java/com/gamja/tiggle/exchange/application/port/in/CreateExchangeApprovalCommand.java
+++ b/src/main/java/com/gamja/tiggle/exchange/application/port/in/CreateExchangeApprovalCommand.java
@@ -1,0 +1,13 @@
+package com.gamja.tiggle.exchange.application.port.in;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class CreateExchangeApprovalCommand {
+    private Long exchangeId;
+    private Long reservationId1;
+    private Long reservationId2;
+    private Boolean isAgree;
+}

--- a/src/main/java/com/gamja/tiggle/exchange/application/port/in/CreateExchangeApprovalUseCase.java
+++ b/src/main/java/com/gamja/tiggle/exchange/application/port/in/CreateExchangeApprovalUseCase.java
@@ -1,0 +1,10 @@
+package com.gamja.tiggle.exchange.application.port.in;
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.exchange.adapter.out.persistence.ExchangeEntity;
+
+public interface CreateExchangeApprovalUseCase {
+    ExchangeEntity findExchangeEntity(Long id) throws BaseException;
+    void create(ExchangeEntity exchangeEntity, CreateExchangeApprovalCommand command) throws BaseException;
+    void reject(ExchangeEntity exchange);
+}

--- a/src/main/java/com/gamja/tiggle/exchange/application/port/out/ExchangePort.java
+++ b/src/main/java/com/gamja/tiggle/exchange/application/port/out/ExchangePort.java
@@ -10,5 +10,7 @@ public interface ExchangePort {
     ExchangeEntity read(Exchange exchange) throws BaseException;
     void save(Exchange exchange);
     Boolean find(CreateExchangeOfferCommand command);
+    ExchangeEntity findById(Long id) throws BaseException;
+    void update(ExchangeEntity exchange);
 
 }

--- a/src/main/java/com/gamja/tiggle/exchange/application/service/CreateExchangeApprovalService.java
+++ b/src/main/java/com/gamja/tiggle/exchange/application/service/CreateExchangeApprovalService.java
@@ -1,0 +1,92 @@
+package com.gamja.tiggle.exchange.application.service;
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.common.BaseResponseStatus;
+import com.gamja.tiggle.common.annotation.UseCase;
+import com.gamja.tiggle.exchange.adapter.out.persistence.ExchangeEntity;
+import com.gamja.tiggle.exchange.application.port.in.CreateExchangeApprovalCommand;
+import com.gamja.tiggle.exchange.application.port.in.CreateExchangeApprovalUseCase;
+import com.gamja.tiggle.exchange.application.port.out.ExchangePort;
+import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.ReservationEntity;
+import com.gamja.tiggle.reservation.application.port.out.ReadReservationPort;
+import com.gamja.tiggle.reservation.application.port.out.SaveReservationPort;
+import com.gamja.tiggle.reservation.domain.Reservation;
+import com.gamja.tiggle.reservation.domain.type.ReservationType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+
+@UseCase
+@RequiredArgsConstructor
+public class CreateExchangeApprovalService implements CreateExchangeApprovalUseCase {
+    private final ExchangePort exchangePort;
+    private final ReadReservationPort readReservationPort;
+    private final SaveReservationPort saveReservationPort;
+
+
+    @Override
+    public ExchangeEntity findExchangeEntity(Long id) throws BaseException {
+        return exchangePort.findById(id);
+    }
+
+    @Override
+    @Transactional
+    public void create(ExchangeEntity exchangeEntity, CreateExchangeApprovalCommand command) throws BaseException {
+//        reservation 찾아오기
+        ReservationEntity reservation1 = readReservationPort.read(Reservation.builder().id(command.getReservationId1()).build());
+        ReservationEntity reservation2 = readReservationPort.read(Reservation.builder().id(command.getReservationId2()).build());
+
+        if(!reservation1.getStatus().equals(ReservationType.COMPLETED) || !reservation2.getStatus().equals(ReservationType.COMPLETED)){
+            throw new BaseException(BaseResponseStatus.UNAVAILABLE_EXCHANGE_OFFER);
+        }
+
+//        티켓 발행
+        saveReservationPort.save(Reservation.builder()
+//                .user(User.builder().id(reservation1.getUser().getId()).build())
+                .programId(reservation1.getProgramEntity().getId())
+                .seatId(reservation1.getSeatEntity().getId())
+                .timesId(reservation1.getTimesEntity().getId())
+                .ticketNumber(getTicketNumber())
+                .totalPrice(reservation1.getTotalPrice())
+                .status(ReservationType.IN_PROGRESS)
+                .requestLimit(5)
+                .build());
+
+//        이전 티켓 상태 변경
+        saveReservationPort.update(updateReservation(reservation1));
+        saveReservationPort.update(updateReservation(reservation2));
+
+//        교환 테이블 상태 변경 => isSuccess, isWatch 상태 바꿈  둘 다 true.
+        exchangePort.update(exchangeEntity.successed(true));
+    }
+
+    private static String getTicketNumber() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
+        String nowDate = LocalDateTime.now().format(formatter);
+        String randomNumber = UUID.randomUUID().toString().substring(0, 4);
+        return nowDate + "-" + randomNumber;
+    }
+
+    public static Reservation updateReservation(ReservationEntity reservation) {
+        return Reservation.builder()
+                .id(reservation.getId())
+                .seatId(reservation.getSeatEntity().getId())
+                .programId(reservation.getProgramEntity().getId())
+                .timesId(reservation.getTimesEntity().getId())
+//                .user(User.builder().id(reservation.getUser().getId()).build())
+                .ticketNumber(reservation.getTicketNumber())
+                .payMethod(reservation.getPayMethod())
+                .totalPrice(reservation.getTotalPrice())
+                .status(ReservationType.EXCHANGED)
+                .requestLimit(reservation.getRequestLimit()).build();
+    }
+
+    @Override
+    public void reject(ExchangeEntity exchange) {
+        exchangePort.update(exchange.successed(false));
+    }
+}

--- a/src/main/java/com/gamja/tiggle/exchange/application/service/CreateExchangeOfferService.java
+++ b/src/main/java/com/gamja/tiggle/exchange/application/service/CreateExchangeOfferService.java
@@ -45,15 +45,14 @@ public class CreateExchangeOfferService implements CreateExchangeOfferUseCase {
                 .timesId(reservation2.getTimesEntity().getId())
                 .ticketNumber(getTicketNumber())
                 .totalPrice(reservation2.getTotalPrice())
-                .status(ReservationType.EXCHANGED)
+                .status(ReservationType.IN_PROGRESS)
                 .requestLimit(5)
                 .build());
 
-//        새로 발행한 티켓 저장
+//        교환 내역 저장
         exchangePort.save(Exchange.builder()
                 .reservationId1(Reservation.builder().id(reservation1.getId()).build())
                 .reservationId2(Reservation.builder().id(reservation2.getId()).build())
-                .isSuccess(false)
                 .isWatch(false)
                 .build());
 
@@ -67,7 +66,7 @@ public class CreateExchangeOfferService implements CreateExchangeOfferUseCase {
                 .ticketNumber(reservation1.getTicketNumber())
                 .payMethod(reservation1.getPayMethod())
                 .totalPrice(reservation1.getTotalPrice())
-                .status(ReservationType.EXCHANGED)
+                .status(reservation1.getStatus())
                 .requestLimit(reservation1.getRequestLimit() - 1).build());
     }
 

--- a/src/main/java/com/gamja/tiggle/exchange/application/service/ReadExchangeOfferService.java
+++ b/src/main/java/com/gamja/tiggle/exchange/application/service/ReadExchangeOfferService.java
@@ -26,6 +26,8 @@ public class ReadExchangeOfferService implements ReadExchangeOfferUseCase {
     private final ExchangePort exchangePort;
     private final ReadReservationPort readReservationPort;
 
+
+
     @Override
     public ReadExchangeOfferResponse read(ReadExchangeOfferCommand command) throws BaseException {
         Exchange exchange = Exchange.builder()
@@ -36,6 +38,8 @@ public class ReadExchangeOfferService implements ReadExchangeOfferUseCase {
 
         ReservationEntity reservation1 = exchangeEntity.getReservation1();
         ReservationEntity reservation2 = exchangeEntity.getReservation2();
+
+        exchangePort.update(exchangeEntity.watched());
 
         return ReadExchangeOfferResponse.builder()
                 .reservationId(reservation2.getId())

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/ReservationEntity.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/ReservationEntity.java
@@ -30,6 +30,7 @@ public class ReservationEntity {
     private ProgramEntity programEntity;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
     private UserEntity user;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/SaveReservationAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/SaveReservationAdapter.java
@@ -9,7 +9,6 @@ import com.gamja.tiggle.reservation.adapter.out.persistence.repositroy.Reservati
 import com.gamja.tiggle.reservation.application.port.out.SaveReservationPort;
 import com.gamja.tiggle.reservation.domain.Reservation;
 import com.gamja.tiggle.reservation.domain.type.ReservationType;
-import com.gamja.tiggle.user.adapter.out.persistence.UserEntity;
 import lombok.RequiredArgsConstructor;
 
 @PersistenceAdapter
@@ -30,6 +29,9 @@ public class SaveReservationAdapter implements SaveReservationPort {
                 .programEntity(new ProgramEntity(reservation.getProgramId()))
                 .timesEntity(new TimesEntity(reservation.getTimesId()))
                 .seatEntity(new SeatEntity(reservation.getSeatId()))
+                .ticketNumber(reservation.getTicketNumber())
+                .requestLimit(reservation.getRequestLimit())
+                .totalPrice(reservation.getTotalPrice())
                 .status(ReservationType.IN_PROGRESS)
                 .build();
     }


### PR DESCRIPTION
## 연관된 이슈
#58 
<br>

## 작업 내용
- 유저가 받은 교환 요청에 대한 응답을 한다.
- 승인 시 이전에 발행한 티켓을 유효하지 않은 상태로 만들고, 새 티켓을 발행한다.
- 거절 시 교환 요청을 거절 상태로 업데이트 한다.
- 다양한 상황에 대한 예외 처리를 했다.
<br> 

## 전달 사항
