### PR TITLE
[Feat] EntityPoint를 이용한 filter 범위 JWT 관련 예외 처리

### DIFF
--- a/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
+++ b/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
@@ -24,6 +24,14 @@ public enum BaseResponseStatus {
      * 2000: 유저
      */
     NOT_FOUND_USER(false,2000,"허가되지 않은 사용자 접근 입니다."),
+    /**
+     * 필터 단계에서 확인되는 에러는 실제 에러코드 형태여야 함.
+     */
+    EXPIRED_TOKEN(false,400,"만료된 토큰 입니다."),
+    NOT_INSERT_TOKEN(false,400,"요청 헤더에 토큰이 존재하지 않습니다."),
+    NOT_MATCH_USERDATA_TOKEN(false,400,"토큰의 정보와 유저의 데이터가 일치 하지 않습니다."),
+    UNSIGNED_FORMAT_TOKEN(false,400,"지원하지 않는 형태의 JWT 토큰 양식 입니다."),
+
 
     /**
      * 3000: 프로그램

--- a/src/main/java/com/gamja/tiggle/config/SecurityConfig.java
+++ b/src/main/java/com/gamja/tiggle/config/SecurityConfig.java
@@ -1,10 +1,10 @@
 package com.gamja.tiggle.config;
 
-
 import com.gamja.tiggle.config.filter.JwtFilter;
 import com.gamja.tiggle.config.filter.LoginFilter;
 import com.gamja.tiggle.utils.JwtUtil;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -20,8 +20,6 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
     private final JwtUtil jwtUtil;
     private final AuthenticationConfiguration authenticationConfiguration;
-    //private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
-    //private final OAuth2Service oAuth2Service;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -29,26 +27,15 @@ public class SecurityConfig {
         http.httpBasic((auth) -> auth.disable());
         http.formLogin((auth) -> auth.disable());
         http.sessionManagement((auth) -> auth.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
-        // 특정 페이지를 차단하고 나머지 다 허용 - 블랙리스트
-        // 특정 페이지를 허용하고 나머지 다 차단 - 화이트리스트
 
         http.authorizeHttpRequests((auth) ->
-                        auth
-//                        .requestMatchers(HttpMethod.GET, "//**", "/admin/**").has("ADMIN")
-//                        .requestMatchers("/test/**", "/mypage").authenticated()
-                       .requestMatchers("/login", "/user/**", "/program/**").permitAll()
-//                        .anyRequest().authenticated()
-
-                                .anyRequest().authenticated()
+                auth
+                        .requestMatchers("user/**", "login/**").permitAll()
+                        .anyRequest().authenticated()
         );
 
         http.addFilterBefore(new JwtFilter(jwtUtil), LoginFilter.class);
         http.addFilterAt(new LoginFilter(jwtUtil, authenticationManager(authenticationConfiguration)), UsernamePasswordAuthenticationFilter.class);
-//        http.oauth2Login((config) -> {
-//            config.successHandler(oAuth2AuthenticationSuccessHandler);
-//            config.userInfoEndpoint((endpoint) -> endpoint.userService(oAuth2Service));
-//        });
-
         return http.build();
     }
 

--- a/src/main/java/com/gamja/tiggle/config/filter/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/gamja/tiggle/config/filter/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package com.gamja.tiggle.config.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.common.BaseResponse;
+import com.gamja.tiggle.common.BaseResponseStatus;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+    }
+
+    public void commenceBaseResponse(HttpServletRequest request, HttpServletResponse response, BaseResponse br) throws IOException, ServletException {
+        setResponse(response, br);
+        Map<String, Object> res = new HashMap<>();
+        res.put("FILTER ERROR", br);
+        String json = new ObjectMapper().writeValueAsString(res);
+        response.getWriter().write(json);
+    }
+
+    private void setResponse(HttpServletResponse response, BaseResponse exceptionDto) {
+        response.setStatus(exceptionDto.getCode());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+    }
+}

--- a/src/main/java/com/gamja/tiggle/config/filter/LoginFilter.java
+++ b/src/main/java/com/gamja/tiggle/config/filter/LoginFilter.java
@@ -1,6 +1,7 @@
 package com.gamja.tiggle.config.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.user.adapter.in.web.request.LoginUserRequest;
 import com.gamja.tiggle.user.domain.CustomUserDetails;
 import com.gamja.tiggle.utils.JwtUtil;
@@ -9,6 +10,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import okhttp3.internal.http2.ErrorCode;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;

--- a/src/main/java/com/gamja/tiggle/program/adapter/out/persistence/ProgramPersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/program/adapter/out/persistence/ProgramPersistenceAdapter.java
@@ -87,7 +87,6 @@ public class ProgramPersistenceAdapter implements CreateProgramPort, ReadProgram
                         .imageUrls(p.getProgramImageEntities().stream().map(programImageEntity -> programImageEntity.getImgUrl()).collect(Collectors.toList()))
                         .build())
                 .collect(Collectors.toUnmodifiableList());
-
         return programs;
     }
 


### PR DESCRIPTION
## 연관된 이슈
#57 
<br>

## 작업 내용
CustomAutheticationEntityPoint를 생성하여, filter 단계에서 Baseresponse를 이용한 예외 처리가 가능한 commceBaseResonse메소드를 생성
토큰의 유무, 양식, 데이터 일치, 만료  4가지 에러에 대해 JSON mapping을 통해 에러를 처리  
<br> 

## 전달 사항
