### PR TITLE
[Fix] fillter 예외 처리 범위 재조정 및 Security Config 허용 범위 설정

### DIFF
--- a/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
+++ b/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
@@ -26,6 +26,11 @@ public enum BaseResponseStatus {
      * 2000: 유저
      */
     NOT_FOUND_USER(false,2000,"허가되지 않은 사용자 접근 입니다."),
+    USER_EMPTY_EMAIL(false,2001,"이메일 등록란은 필수 항목입니다."),
+    USER_EMPTY_NAME(false,2002,"이름 등록란은 필수 항목입니다."),
+    USER_EMPTY_PASSWORD(false,2003,"패스워드 입력란은 필수 항목입니다."),
+
+
     /**
      * 필터 단계에서 확인되는 에러는 실제 에러코드 형태여야 함.
      */

--- a/src/main/java/com/gamja/tiggle/config/SecurityConfig.java
+++ b/src/main/java/com/gamja/tiggle/config/SecurityConfig.java
@@ -4,7 +4,6 @@ import com.gamja.tiggle.config.filter.JwtFilter;
 import com.gamja.tiggle.config.filter.LoginFilter;
 import com.gamja.tiggle.utils.JwtUtil;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;

--- a/src/main/java/com/gamja/tiggle/config/SecurityConfig.java
+++ b/src/main/java/com/gamja/tiggle/config/SecurityConfig.java
@@ -29,7 +29,14 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests((auth) ->
                 auth
-                        .requestMatchers("user/**", "login/**").permitAll()
+                        .requestMatchers("swagger-ui/**",
+                                "user/**", "login/**","program/**",
+                                "swagger-ui.html/**",
+                                "v3/api-docs/**",
+                                "v2/api-docs/**",
+                                "swagger-resources/**",
+                                "swagger-ui/**",
+                                "swagger/**").permitAll()
                         .anyRequest().authenticated()
         );
 

--- a/src/main/java/com/gamja/tiggle/config/filter/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/gamja/tiggle/config/filter/CustomAuthenticationEntryPoint.java
@@ -1,9 +1,7 @@
 package com.gamja.tiggle.config.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.common.BaseResponse;
-import com.gamja.tiggle.common.BaseResponseStatus;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/com/gamja/tiggle/config/filter/JwtFilter.java
+++ b/src/main/java/com/gamja/tiggle/config/filter/JwtFilter.java
@@ -31,14 +31,17 @@ public class JwtFilter extends OncePerRequestFilter {
         User user = null;
         String authorization = null;
         String token = null;
+
+        authorization = request.getHeader("Authorization");
+
+
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            System.out.println("Bearer 토큰이 없음");
+            filterChain.doFilter(request, response);
+            return;
+
+        }
         try {
-            authorization = request.getHeader("Authorization");
-
-
-            if (authorization == null || !authorization.startsWith("Bearer ")) {
-                System.out.println("Bearer 토큰이 없음");
-            }
-
             token = authorization.split(" ")[1];
         } catch (NullPointerException e) {
             CustomAuthenticationEntryPoint authenticationEntryPoint = new CustomAuthenticationEntryPoint();

--- a/src/main/java/com/gamja/tiggle/config/filter/LoginFilter.java
+++ b/src/main/java/com/gamja/tiggle/config/filter/LoginFilter.java
@@ -1,7 +1,6 @@
 package com.gamja.tiggle.config.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.user.adapter.in.web.request.LoginUserRequest;
 import com.gamja.tiggle.user.domain.CustomUserDetails;
 import com.gamja.tiggle.utils.JwtUtil;
@@ -10,14 +9,12 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import okhttp3.internal.http2.ErrorCode;
-import org.springframework.http.MediaType;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.web.authentication.*;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.util.StreamUtils;
 
 import java.io.IOException;
@@ -70,7 +67,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     @Override
     protected void successfulAuthentication(HttpServletRequest request,
                                             HttpServletResponse response, FilterChain chain, Authentication authResult) throws IOException, ServletException {
-        CustomUserDetails user = (CustomUserDetails)authResult.getPrincipal();
+        CustomUserDetails user = (CustomUserDetails) authResult.getPrincipal();
 
         Collection<? extends GrantedAuthority> authorities = authResult.getAuthorities();
         GrantedAuthority auth = authorities.iterator().next();
@@ -82,6 +79,6 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         response.addHeader("Authorization", "Bearer " + token);
         PrintWriter out = response.getWriter();
-        out.println("{\"isSuccess\": true, \"accessToken\": \""+token+"\"}");
+        out.println("{\"isSuccess\": true, \"accessToken\": \"" + token + "\"}");
     }
 }

--- a/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentPersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentPersistenceAdapter.java
@@ -1,13 +1,11 @@
 package com.gamja.tiggle.payment.adapter.out.persistence;
 
 import com.gamja.tiggle.common.BaseException;
-import com.gamja.tiggle.common.BaseResponse;
 import com.gamja.tiggle.common.BaseResponseStatus;
 import com.gamja.tiggle.payment.application.port.out.PaymentPersistencePort;
 import com.gamja.tiggle.payment.domain.Payment;
 import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.ReservationEntity;
 import com.gamja.tiggle.reservation.adapter.out.persistence.repositroy.ReservationRepository;
-import com.gamja.tiggle.reservation.domain.Reservation;
 import com.gamja.tiggle.reservation.domain.type.ReservationType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/gamja/tiggle/payment/domain/Payment.java
+++ b/src/main/java/com/gamja/tiggle/payment/domain/Payment.java
@@ -1,7 +1,6 @@
 package com.gamja.tiggle.payment.domain;
 
 import lombok.AllArgsConstructor;
-
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/gamja/tiggle/reservation/domain/Reservation.java
+++ b/src/main/java/com/gamja/tiggle/reservation/domain/Reservation.java
@@ -6,8 +6,10 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Builder
 public class Reservation {
 

--- a/src/main/java/com/gamja/tiggle/user/adapter/in/web/SignupUserController.java
+++ b/src/main/java/com/gamja/tiggle/user/adapter/in/web/SignupUserController.java
@@ -8,7 +8,12 @@ import com.gamja.tiggle.user.adapter.in.web.request.SignupUserRequest;
 import com.gamja.tiggle.user.application.port.in.SignupUserCommand;
 import com.gamja.tiggle.user.application.port.in.SignupUserUseCase;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.gamja.tiggle.common.BaseResponseStatus.*;
 
 
 @RestController
@@ -19,14 +24,15 @@ public class SignupUserController {
 
     @PostMapping("/signup")
     BaseResponse signup(@RequestBody SignupUserRequest request) {
-//        if(request.getEmail() == null){
-//            return new BaseResponse<>(POST_USERS_EMPTY_EMAIL);
-//        }
-//        if(request.getName() == null){
-//            return new BaseResponse<>(POST_USERS_EMPTY_NAME);
-//        }
-//        if(request.getPassword() == null){
-//            return new BaseResponse<>(POST_USERS_EMPTY_PASSWORD);
+        if (request.getEmail() == null) {
+            return new BaseResponse<>(USER_EMPTY_EMAIL);
+        }
+        if (request.getName() == null) {
+           return new BaseResponse<>(USER_EMPTY_NAME);
+       }
+        if(request.getPassword() == null) {
+            return new BaseResponse<>(USER_EMPTY_PASSWORD);
+        }
 
         SignupUserCommand command = SignupUserCommand.builder()
                 .name(request.getName())

--- a/src/main/java/com/gamja/tiggle/user/adapter/in/web/VerifyUserController.java
+++ b/src/main/java/com/gamja/tiggle/user/adapter/in/web/VerifyUserController.java
@@ -4,13 +4,12 @@ package com.gamja.tiggle.user.adapter.in.web;
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.common.BaseResponse;
 import com.gamja.tiggle.common.BaseResponseStatus;
-import com.gamja.tiggle.user.adapter.in.web.request.SignupUserRequest;
-import com.gamja.tiggle.user.application.port.in.SignupUserCommand;
-import com.gamja.tiggle.user.application.port.in.SignupUserUseCase;
 import com.gamja.tiggle.user.application.port.in.VerifyUserCommand;
 import com.gamja.tiggle.user.application.port.in.VerifyUserUseCase;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 
 @RestController

--- a/src/main/java/com/gamja/tiggle/user/application/service/CustomUserDetailService.java
+++ b/src/main/java/com/gamja/tiggle/user/application/service/CustomUserDetailService.java
@@ -27,7 +27,7 @@ public class CustomUserDetailService implements UserDetailsService {
                 .enable(true)
                 .build();
 
-        if (result!=null) {
+        if (result != null) {
             return new CustomUserDetails(user);
         } else {
             return null;

--- a/src/main/java/com/gamja/tiggle/user/application/service/SignupUserService.java
+++ b/src/main/java/com/gamja/tiggle/user/application/service/SignupUserService.java
@@ -1,7 +1,6 @@
 package com.gamja.tiggle.user.application.service;
 
 import com.gamja.tiggle.common.BaseException;
-import com.gamja.tiggle.user.adapter.out.persistence.EmailVerify;
 import com.gamja.tiggle.user.application.port.in.SignupUserCommand;
 import com.gamja.tiggle.user.application.port.in.SignupUserUseCase;
 import com.gamja.tiggle.user.application.port.out.EmailVerifyPort;

--- a/src/main/java/com/gamja/tiggle/user/application/service/VerifyUserService.java
+++ b/src/main/java/com/gamja/tiggle/user/application/service/VerifyUserService.java
@@ -2,13 +2,10 @@ package com.gamja.tiggle.user.application.service;
 
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.user.adapter.out.persistence.EmailVerify;
-import com.gamja.tiggle.user.application.port.in.SignupUserCommand;
-import com.gamja.tiggle.user.application.port.in.SignupUserUseCase;
 import com.gamja.tiggle.user.application.port.in.VerifyUserCommand;
 import com.gamja.tiggle.user.application.port.in.VerifyUserUseCase;
 import com.gamja.tiggle.user.application.port.out.EmailVerifyPort;
 import com.gamja.tiggle.user.application.port.out.UserPersistencePort;
-import com.gamja.tiggle.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -21,7 +18,7 @@ public class VerifyUserService implements VerifyUserUseCase {
     @Override
     public void verify(VerifyUserCommand command) throws BaseException {
         EmailVerify emailVerify = emailVerifyPort.findByEmail(command.getEmail());
-        if(emailVerify.getUuid().equals(command.getUuid())) {
+        if (emailVerify.getUuid().equals(command.getUuid())) {
             userPersistencePort.verifyUser(command.getEmail());
         }
     }


### PR DESCRIPTION
## 연관된 이슈
#57 
<br>

## 작업 내용
Jwt Fillter의 예외 처리 범위에서 초기 Bear토큰 유무를 확인하고, 새 토큰 생성 과정을 제외
Security Config의 permitAll 범위에 Swagger 및 user/, login/, program/ 지정
<br> 

## 전달 사항
