### PR TITLE
[Refactor] 공연 조회 예매시간 추가 #86

### DIFF
--- a/src/main/java/com/gamja/tiggle/program/adapter/in/web/ReadProgramController.java
+++ b/src/main/java/com/gamja/tiggle/program/adapter/in/web/ReadProgramController.java
@@ -38,15 +38,14 @@ public class ReadProgramController {
             List<ReadProgramResponse> responses = program.stream()
                     .map(p -> ReadProgramResponse.builder()
                             .programName(p.getProgramName())
+                            .reservationOpenDate(p.getReservationOpenDate())
                             .programInfo(p.getProgramInfo())
                             .programStartDate(p.getProgramStartDate())
                             .programEndDate(p.getProgramEndDate())
                             .imageFiles(p.getImageUrls())
                             .build())
                     .collect(Collectors.toList());
-
             return new BaseResponse<>(BaseResponseStatus.SUCCESS, responses);
-
         } catch (BaseException e) {
             return new BaseResponse<>(BaseResponseStatus.FAIL, null);
         }

--- a/src/main/java/com/gamja/tiggle/program/adapter/out/persistence/ProgramPersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/program/adapter/out/persistence/ProgramPersistenceAdapter.java
@@ -67,6 +67,7 @@ public class ProgramPersistenceAdapter implements CreateProgramPort, ReadProgram
                         .categoryId(p.getCategoryEntity().getId())
                         .programName(p.getProgramName())
                         .programInfo(p.getProgramInfo())
+                        .reservationOpenDate(p.getReservationOpenDate())
                         .programStartDate(p.getProgramStartDate())
                         .programEndDate(p.getProgramEndDate())
                         .imageUrls(p.getProgramImageEntities().stream().map(programImageEntity -> programImageEntity.getImgUrl()).toList())


### PR DESCRIPTION
## 연관된 이슈
[Refactor] 공연 조회 예매 시간 추가 #86
<br>

## 작업 내용
공연 조회 목록에 예매 시간 가능하게 추가까지 했습니다 ,, 
<br> 

## 전달 사항
메인 화면 보여줄 거에 예매 시간이 필요하길래 추가 했습니다 ++ 불필요한 import 제거