### PR TITLE
[Feat] 전체 좌석 조회 및 예약 가능 좌석 조회 수정

### DIFF
--- a/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
+++ b/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
@@ -11,7 +11,6 @@ public enum BaseResponseStatus {
     FAIL(false, 500, "요청 실패"),
 
 
-
     /**
      * 1000 : 요청 성공
      */
@@ -25,19 +24,19 @@ public enum BaseResponseStatus {
     /**
      * 2000: 유저
      */
-    NOT_FOUND_USER(false,2000,"허가되지 않은 사용자 접근 입니다."),
-    USER_EMPTY_EMAIL(false,2001,"이메일 등록란은 필수 항목입니다."),
-    USER_EMPTY_NAME(false,2002,"이름 등록란은 필수 항목입니다."),
-    USER_EMPTY_PASSWORD(false,2003,"패스워드 입력란은 필수 항목입니다."),
+    NOT_FOUND_USER(false, 2000, "허가되지 않은 사용자 접근 입니다."),
+    USER_EMPTY_EMAIL(false, 2001, "이메일 등록란은 필수 항목입니다."),
+    USER_EMPTY_NAME(false, 2002, "이름 등록란은 필수 항목입니다."),
+    USER_EMPTY_PASSWORD(false, 2003, "패스워드 입력란은 필수 항목입니다."),
 
 
     /**
      * 필터 단계에서 확인되는 에러는 실제 에러코드 형태여야 함.
      */
-    EXPIRED_TOKEN(false,400,"만료된 토큰 입니다."),
-    NOT_INSERT_TOKEN(false,400,"요청 헤더에 토큰이 존재하지 않습니다."),
-    NOT_MATCH_USERDATA_TOKEN(false,400,"토큰의 정보와 유저의 데이터가 일치 하지 않습니다."),
-    UNSIGNED_FORMAT_TOKEN(false,400,"지원하지 않는 형태의 JWT 토큰 양식 입니다."),
+    EXPIRED_TOKEN(false, 400, "만료된 토큰 입니다."),
+    NOT_INSERT_TOKEN(false, 400, "요청 헤더에 토큰이 존재하지 않습니다."),
+    NOT_MATCH_USERDATA_TOKEN(false, 400, "토큰의 정보와 유저의 데이터가 일치 하지 않습니다."),
+    UNSIGNED_FORMAT_TOKEN(false, 400, "지원하지 않는 형태의 JWT 토큰 양식 입니다."),
 
     /**
      * 3000: 프로그램
@@ -60,28 +59,27 @@ public enum BaseResponseStatus {
     /**
      * 4000: 결제
      */
-    NOT_FOUND_PAYMENT(false,4000,"결제 정보가 존재하지 않습니다."),
-    INCORRECT_PAYMENT_INFO(false,4100,"잘못된 결제 정보 입니다."),
-    WRONG_API_SECRET(false,4101,"잘못된 API KEY 입니다. 데이터와 만료 시기를 확인해 주시기 바랍니다."),
-    WRONG_PAYMENT_ID(false,4102,"결제 ID 코드값을 다시 확인해 주시기 바랍니다."),
+    NOT_FOUND_PAYMENT(false, 4000, "결제 정보가 존재하지 않습니다."),
+    INCORRECT_PAYMENT_INFO(false, 4100, "잘못된 결제 정보 입니다."),
+    WRONG_API_SECRET(false, 4101, "잘못된 API KEY 입니다. 데이터와 만료 시기를 확인해 주시기 바랍니다."),
+    WRONG_PAYMENT_ID(false, 4102, "결제 ID 코드값을 다시 확인해 주시기 바랍니다."),
 
-    NOT_AGREE_PAYMENT_RULE(false,4101,"결제 주의 사항에 동의가 반드시 필요합니다."),
-    INCORRECT_RESERVATION_DATA(false,4200,"잘못된 예매 정보입니다."),
-    ALREADY_PAID_TICKET(false,4201,"이미 결제된 티켓입니다."),
+    NOT_AGREE_PAYMENT_RULE(false, 4101, "결제 주의 사항에 동의가 반드시 필요합니다."),
+    INCORRECT_RESERVATION_DATA(false, 4200, "잘못된 예매 정보입니다."),
+    ALREADY_PAID_TICKET(false, 4201, "이미 결제된 티켓입니다."),
 
-    NOT_FOUND_PAYMENT_DATA(false,4300,"진행되지 않은 결제 데이터입니다."),
-    FAIL_CANCELED_PAYMENT(false,4301,"잘못된 결제 데이터로 인해 시스템 결제 취소를 시도했으나 실패하였습니다. 결제 기록을 확인하고 환불 처리를 신청해주시길 바랍니다."),
-    INCORRECT_DATA_CANCEL_SUCCESS(false,4302,"잘못된 결제과정에서 오류가 발생하여 결제를 정상 취소했습니다."),
-
-
+    NOT_FOUND_PAYMENT_DATA(false, 4300, "진행되지 않은 결제 데이터입니다."),
+    FAIL_CANCELED_PAYMENT(false, 4301, "잘못된 결제 데이터로 인해 시스템 결제 취소를 시도했으나 실패하였습니다. 결제 기록을 확인하고 환불 처리를 신청해주시길 바랍니다."),
+    INCORRECT_DATA_CANCEL_SUCCESS(false, 4302, "잘못된 결제과정에서 오류가 발생하여 결제를 정상 취소했습니다."),
 
 
     /**
      * 5000: 예매
      */
-    ALREADY_CHOSEN_SEAT(false,5000,"이미 선택된 좌석입니다."),
-    NOT_FOUND_RESERVATION(false,5001,"결제 정보가 존재하지 않습니다."),
+    ALREADY_CHOSEN_SEAT(false, 5000, "이미 선택된 좌석입니다."),
+    NOT_FOUND_RESERVATION(false, 5001, "결제 정보가 존재하지 않습니다."),
     NOT_FOUND_TIMES(false, 5002, "회차 정보가 존재하지 않습니다."),
+    NOT_FOUND_SEAT(false, 5003, "좌석 정보가 존재하지 않습니다."),
 
 
     /**
@@ -99,12 +97,11 @@ public enum BaseResponseStatus {
     NOT_EXCHANGE_OFFER(false, 6008, "요청받은 교환이 존재하지 않습니다."),
 
 
-
     /**
      * 7000: 공연장, 구역, 좌석, 등급
      */
-    NOT_FOUND_SECTION(false,7000,"구역이 존재하지 않습니다."),
-    NOT_FOUND_PRICE(false,7001,"등급별 가격 정보가 존재하지 않습니다."),
+    NOT_FOUND_SECTION(false, 7000, "구역이 존재하지 않습니다."),
+    NOT_FOUND_PRICE(false, 7001, "등급별 가격 정보가 존재하지 않습니다."),
 
     /**
      * 8000: 공통 에러

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSeatController.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSeatController.java
@@ -32,6 +32,7 @@ public class GetSeatController {
 
 
     @PostMapping("/all")
+    @Operation(summary = "전체 좌석 조회", description = "특정 공연의 전체 좌석을 조회하는 API 입니다.")
     public BaseResponse<List<List<GetAllSeatResponse>>> getAllSeat(
             @RequestBody GetAllSeatRequest request,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSeatController.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSeatController.java
@@ -4,10 +4,13 @@ package com.gamja.tiggle.reservation.adapter.in.web;
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.common.BaseResponse;
 import com.gamja.tiggle.common.annotation.WebAdapter;
+import com.gamja.tiggle.reservation.adapter.in.web.request.GetAllSeatRequest;
 import com.gamja.tiggle.reservation.adapter.in.web.request.GetAvailableSeatRequest;
+import com.gamja.tiggle.reservation.adapter.in.web.response.GetAllSeatResponse;
 import com.gamja.tiggle.reservation.adapter.in.web.response.GetAvailableSeatResponse;
+import com.gamja.tiggle.reservation.application.port.in.GetAllSeatCommand;
 import com.gamja.tiggle.reservation.application.port.in.GetAvailableSeatCommand;
-import com.gamja.tiggle.reservation.application.port.in.GetAvailableSeatUseCase;
+import com.gamja.tiggle.reservation.application.port.in.GetSeatUseCase;
 import com.gamja.tiggle.reservation.domain.Seat;
 import com.gamja.tiggle.user.domain.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,14 +21,45 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @WebAdapter
 @RequiredArgsConstructor
 @RequestMapping("/seat")
 public class GetSeatController {
 
-    private final GetAvailableSeatUseCase getAvailableSeatUseCase;
+    private final GetSeatUseCase getSeatUseCase;
 
+
+    @PostMapping("/all")
+    public BaseResponse<List<List<GetAllSeatResponse>>> getAllSeat(
+            @RequestBody GetAllSeatRequest request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
+
+
+        List<List<GetAllSeatResponse>> AllSeatResponse;
+        try {
+            List<List<Seat>> allSeat = getSeatUseCase.getAllSeat(toAllSeatCommand(request));
+            AllSeatResponse = allSeat.stream()
+                    .map(row -> row.stream()
+                            .map(this::toGetAllSeatResponse)
+                            .collect(Collectors.toList()))
+                    .collect(Collectors.toList());
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+        return new BaseResponse<>(AllSeatResponse);
+
+    }
+
+    public GetAllSeatResponse toGetAllSeatResponse(Seat seat) {
+        return GetAllSeatResponse.builder()
+                .seatId(seat.getId())
+                .seatNumber(seat.getSeatNumber())
+                .active(seat.getActive())
+                .row(seat.getRow())
+                .build();
+    }
 
     @PostMapping
     @Operation(summary = "예약 가능 좌석 조회", description = "특정 공연의 예약 가능 좌석을 조회하는 API 입니다.")
@@ -36,7 +70,7 @@ public class GetSeatController {
         GetAvailableSeatCommand command = toCommand(request);
         List<GetAvailableSeatResponse> list;
         try {
-            list = getAvailableSeatUseCase.getAvailableSeat(command).stream().map(seat -> getResponse(seat)
+            list = getSeatUseCase.getAvailableSeat(command).stream().map(seat -> getResponse(seat)
             ).toList();
         } catch (BaseException e) {
             return new BaseResponse<>(e.getStatus());
@@ -45,16 +79,20 @@ public class GetSeatController {
         return new BaseResponse<>(list);
     }
 
-    private static GetAvailableSeatResponse getResponse(Seat seat) {
+    /**
+     * dto 변환
+     */
+
+    private GetAvailableSeatResponse getResponse(Seat seat) {
         return GetAvailableSeatResponse.builder()
                 .seatId(seat.getId())
                 .seatNumber(seat.getSeatNumber())
-                .sectionId(seat.getSectionId())
+                .row(seat.getRow())
                 .build();
     }
 
 
-    private static GetAvailableSeatCommand toCommand(GetAvailableSeatRequest request) {
+    private GetAvailableSeatCommand toCommand(GetAvailableSeatRequest request) {
         return GetAvailableSeatCommand
                 .builder()
                 .programId(request.getProgramId())
@@ -62,4 +100,25 @@ public class GetSeatController {
                 .sectionId(request.getSectionId())
                 .build();
     }
+
+    private GetAllSeatResponse getAllSeatResponse(Seat seat) {
+        return GetAllSeatResponse
+                .builder()
+                .seatId(seat.getId())
+                .seatNumber(seat.getSeatNumber())
+                .active(seat.getActive())
+                .row(seat.getRow())
+                .build();
+    }
+
+    private GetAllSeatCommand toAllSeatCommand(GetAllSeatRequest request) {
+        return GetAllSeatCommand
+                .builder()
+                .programId(request.getProgramId())
+                .timesId(request.getTimesId())
+                .sectionId(request.getSectionId())
+                .build();
+    }
+
+
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/request/GetAllSeatRequest.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/request/GetAllSeatRequest.java
@@ -1,0 +1,13 @@
+package com.gamja.tiggle.reservation.adapter.in.web.request;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetAllSeatRequest {
+
+    private Long programId;
+    private Long timesId;
+    private Long sectionId;
+}

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/GetAllSeatResponse.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/GetAllSeatResponse.java
@@ -1,14 +1,17 @@
 package com.gamja.tiggle.reservation.adapter.in.web.response;
 
-
 import lombok.Builder;
 import lombok.Getter;
 
 @Builder
 @Getter
-public class GetAvailableSeatResponse {
+public class GetAllSeatResponse {
+
 
     private Long seatId;
-    private int seatNumber;
+
     private String row;
+    private int seatNumber;
+    private Boolean active;
+
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/GetSectionListResponse.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/GetSectionListResponse.java
@@ -11,4 +11,7 @@ public class GetSectionListResponse {
     private String sectionName;
     private Long gradeId;
 
+    private int rowCount;
+    private int columnCount;
+
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/SeatEntity.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/SeatEntity.java
@@ -24,6 +24,9 @@ public class SeatEntity {
 
     private int seatNumber;
 
+    private String row;
+    private Boolean active;
+
     public SeatEntity(Long id) {
         this.id = id;
     }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/SectionEntity.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/SectionEntity.java
@@ -21,6 +21,9 @@ public class SectionEntity {
     private Long id;
     private String sectionName;
 
+    private int rowCount; // 행
+    private int columnCount; // 열
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "location_id")
     private LocationEntity locationEntity;

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSectionAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSectionAdapter.java
@@ -19,14 +19,18 @@ public class GetSectionAdapter implements GetSectionPort {
 
     @Override
     public List<Section> getSection(Long id) throws BaseException {
-        System.out.println("aa");
         List<SectionEntity> allByLocationId = sectionRepository.findAllByLocationEntityId(id);
         if (allByLocationId.isEmpty()) {
             throw new BaseException(BaseResponseStatus.NOT_FOUND_SECTION);
         }
-        System.out.println(allByLocationId);
-        System.out.println(allByLocationId.get(0).getId());
         return from(allByLocationId);
+    }
+
+    @Override
+    public Section getRowColumn(Long id) throws BaseException {
+        SectionEntity sectionEntity = sectionRepository.findById(id).orElseThrow(() ->
+                new BaseException(BaseResponseStatus.NOT_FOUND_SECTION));
+        return from(sectionEntity);
     }
 
     private List<Section> from(List<SectionEntity> allByLocationId) {
@@ -38,5 +42,13 @@ public class GetSectionAdapter implements GetSectionPort {
                         .sectionName(sectionEntity.getSectionName())
                         .build()
         ).toList();
+    }
+
+    private Section from(SectionEntity entity) {
+        return Section
+                .builder()
+                .rowCount(entity.getRowCount())
+                .columnCount(entity.getColumnCount())
+                .build();
     }
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Response/GetSeatResponse.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Response/GetSeatResponse.java
@@ -10,12 +10,13 @@ public class GetSeatResponse {
     private Long seatId;
     private Long sectionId;
     private int seatNumber;
+    private String row;
 
 
-    public GetSeatResponse(Long seatId, Long sectionId, int seatNumber) {
+    public GetSeatResponse(Long seatId, Long sectionId, int seatNumber, String row) {
         this.seatId = seatId;
         this.sectionId = sectionId;
         this.seatNumber = seatNumber;
-
+        this.row = row;
     }
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/getSeatAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/getSeatAdapter.java
@@ -6,7 +6,7 @@ import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.SeatEntity;
 import com.gamja.tiggle.reservation.adapter.out.persistence.Response.GetSeatResponse;
 import com.gamja.tiggle.reservation.adapter.out.persistence.repositroy.ReservationRepository;
 import com.gamja.tiggle.reservation.adapter.out.persistence.repositroy.SeatRepository;
-import com.gamja.tiggle.reservation.application.port.out.GetAvailableSeatPort;
+import com.gamja.tiggle.reservation.application.port.out.GetSeatPort;
 import com.gamja.tiggle.reservation.domain.Seat;
 import lombok.RequiredArgsConstructor;
 
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 
 @PersistenceAdapter
 @RequiredArgsConstructor
-public class getAvailableSeatAdapter implements GetAvailableSeatPort {
+public class getSeatAdapter implements GetSeatPort {
 
     private final SeatRepository seatRepository;
     private final ReservationRepository reservationRepository;
@@ -77,6 +77,14 @@ public class getAvailableSeatAdapter implements GetAvailableSeatPort {
                         .sectionId(getSeatResponse.getSectionId())
                         .build()).toList();
         return list;
+    }
+
+
+    @Override
+    public List<Seat> getAllSeat(Long programId, Long sectionId, Long timesId, int rowCount, int columnCount) {
+
+
+        return null;
     }
 }
 

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/SeatRepository.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/SeatRepository.java
@@ -7,15 +7,19 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SeatRepository extends JpaRepository<SeatEntity, Long> {
 
 
-    List<SeatEntity> findAllBySectionEntityId(Long sectionId);
+    Optional<List<SeatEntity>> findAllBySectionEntityId(Long sectionId);
 
-//예약 가능 좌석만 조회
+    @Query("SELECT s FROM SeatEntity s WHERE s.sectionEntity.id = :sectionId ORDER BY s.row, s.seatNumber")
+    List<SeatEntity> findAllBySectionEntityIdByQuery(@Param("sectionId") Long sectionId);
+
+    //예약 가능 좌석만 조회
     @Query("SELECT new com.gamja.tiggle.reservation.adapter.out.persistence.Response" +
-            ".GetSeatResponse(s.id, s.sectionEntity.id, s.seatNumber) " +
+            ".GetSeatResponse(s.id, s.sectionEntity.id, s.seatNumber, s.row) " +
             "FROM SeatEntity s " +
             "LEFT JOIN ReservationEntity r ON s.id = r.seatEntity.id " +
             "AND r.programEntity.id = :programId " +

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetAllSeatCommand.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetAllSeatCommand.java
@@ -1,0 +1,13 @@
+package com.gamja.tiggle.reservation.application.port.in;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetAllSeatCommand {
+
+    private Long programId;
+    private Long timesId;
+    private Long sectionId;
+}

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetSeatUseCase.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetSeatUseCase.java
@@ -5,6 +5,8 @@ import com.gamja.tiggle.reservation.domain.Seat;
 
 import java.util.List;
 
-public interface GetAvailableSeatUseCase {
+public interface GetSeatUseCase {
     List<Seat> getAvailableSeat(GetAvailableSeatCommand command) throws BaseException;
+
+    List<Seat> getAllSeat(GetAllSeatCommand command) throws  BaseException;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetSeatUseCase.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetSeatUseCase.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface GetSeatUseCase {
     List<Seat> getAvailableSeat(GetAvailableSeatCommand command) throws BaseException;
 
-    List<Seat> getAllSeat(GetAllSeatCommand command) throws  BaseException;
+    List<List<Seat>> getAllSeat(GetAllSeatCommand command) throws BaseException;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSeatPort.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSeatPort.java
@@ -1,12 +1,14 @@
 package com.gamja.tiggle.reservation.application.port.out;
 
+import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.reservation.domain.Seat;
 
 import java.util.List;
 
 public interface GetSeatPort {
     List<Seat> getAvailableSeatByQuery(Long programId, Long timesId, Long sectionId);
-    List<Seat> getAvailableSeatByJpa(Long programId, Long timesId, Long sectionId);
 
-    List<Seat> getAllSeat(Long programId, Long sectionId, Long timesId, int rowCount, int columnCount);
+    List<Seat> getAvailableSeatByJpa(Long programId, Long timesId, Long sectionId) throws BaseException;
+
+    List<Seat> getAllSeat(Long programId, Long sectionId, Long timesId) throws BaseException;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSeatPort.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSeatPort.java
@@ -4,7 +4,9 @@ import com.gamja.tiggle.reservation.domain.Seat;
 
 import java.util.List;
 
-public interface GetAvailableSeatPort {
+public interface GetSeatPort {
     List<Seat> getAvailableSeatByQuery(Long programId, Long timesId, Long sectionId);
     List<Seat> getAvailableSeatByJpa(Long programId, Long timesId, Long sectionId);
+
+    List<Seat> getAllSeat(Long programId, Long sectionId, Long timesId, int rowCount, int columnCount);
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSectionPort.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSectionPort.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface GetSectionPort {
 
     List<Section> getSection(Long id) throws BaseException;
+    Section getRowColumn(Long id) throws BaseException;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/service/GetSeatService.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/service/GetSeatService.java
@@ -4,9 +4,10 @@ import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.common.BaseResponseStatus;
 import com.gamja.tiggle.common.annotation.UseCase;
 import com.gamja.tiggle.program.application.port.out.ProgramPort;
+import com.gamja.tiggle.reservation.application.port.in.GetAllSeatCommand;
 import com.gamja.tiggle.reservation.application.port.in.GetAvailableSeatCommand;
-import com.gamja.tiggle.reservation.application.port.in.GetAvailableSeatUseCase;
-import com.gamja.tiggle.reservation.application.port.out.GetAvailableSeatPort;
+import com.gamja.tiggle.reservation.application.port.in.GetSeatUseCase;
+import com.gamja.tiggle.reservation.application.port.out.GetSeatPort;
 import com.gamja.tiggle.reservation.domain.Seat;
 import lombok.RequiredArgsConstructor;
 
@@ -14,24 +15,32 @@ import java.util.List;
 
 @UseCase
 @RequiredArgsConstructor
-public class GetAvailableSeatService implements GetAvailableSeatUseCase {
-    private final GetAvailableSeatPort getAvailableSeatPort;
+public class GetSeatService implements GetSeatUseCase {
+    private final GetSeatPort getSeatPort;
     private final ProgramPort programPort;
 
 
     @Override
     public List<Seat> getAvailableSeat(GetAvailableSeatCommand command) throws BaseException {
 
-        System.out.println(command.getProgramId());
         if (!programPort.existProgram(command.getProgramId())) {
             throw new BaseException(BaseResponseStatus.NOT_FOUND_PROGRAM);
         }
-
-        System.out.println("???");
-
-        return getAvailableSeatPort.getAvailableSeatByQuery(
+        return getSeatPort.getAvailableSeatByQuery(
                 command.getProgramId(),
                 command.getTimesId(),
                 command.getSectionId());
     }
+
+    @Override
+    public List<Seat> getAllSeat(GetAllSeatCommand command) throws BaseException {
+
+        return getSeatPort.getAllSeat(command.getProgramId(),
+                command.getSectionId(),
+                command.getTimesId(),
+                command.getRowCount(),
+                command.getColumnCount());
+    }
+
+
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/service/GetSeatService.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/service/GetSeatService.java
@@ -8,9 +8,13 @@ import com.gamja.tiggle.reservation.application.port.in.GetAllSeatCommand;
 import com.gamja.tiggle.reservation.application.port.in.GetAvailableSeatCommand;
 import com.gamja.tiggle.reservation.application.port.in.GetSeatUseCase;
 import com.gamja.tiggle.reservation.application.port.out.GetSeatPort;
+import com.gamja.tiggle.reservation.application.port.out.GetSectionPort;
 import com.gamja.tiggle.reservation.domain.Seat;
+import com.gamja.tiggle.reservation.domain.Section;
 import lombok.RequiredArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @UseCase
@@ -18,6 +22,7 @@ import java.util.List;
 public class GetSeatService implements GetSeatUseCase {
     private final GetSeatPort getSeatPort;
     private final ProgramPort programPort;
+    private final GetSectionPort sectionPort;
 
 
     @Override
@@ -33,13 +38,30 @@ public class GetSeatService implements GetSeatUseCase {
     }
 
     @Override
-    public List<Seat> getAllSeat(GetAllSeatCommand command) throws BaseException {
+    public List<List<Seat>> getAllSeat(GetAllSeatCommand command) throws BaseException {
 
-        return getSeatPort.getAllSeat(command.getProgramId(),
+        List<Seat> allSeat = getSeatPort.getAllSeat(command.getProgramId(),
                 command.getSectionId(),
-                command.getTimesId(),
-                command.getRowCount(),
-                command.getColumnCount());
+                command.getTimesId()
+        );
+        Section section = sectionPort.getRowColumn(command.getSectionId());
+
+        int rowCount = section.getRowCount();
+        int columnCount = section.getColumnCount();
+        List<List<Seat>> ArraySeat = new ArrayList<>();
+
+        for (int i = 0; i < rowCount; i++) {
+            ArraySeat.add(new ArrayList<>(Collections.nCopies(columnCount, null)));
+        }
+
+        for (Seat seat : allSeat) {
+            int rowIndex = seat.getRow().charAt(0) - 'A';
+            int colIndex = seat.getSeatNumber() - 1;
+            ArraySeat.get(rowIndex).set(colIndex, seat);
+        }
+
+
+        return ArraySeat;
     }
 
 

--- a/src/main/java/com/gamja/tiggle/reservation/application/service/GetSectionService.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/service/GetSectionService.java
@@ -17,7 +17,6 @@ public class GetSectionService implements GetSectionUseCase {
 
     @Override
     public List<Section> getSection(Long locationId) throws BaseException {
-        System.out.println("locationId = " + locationId);
         return getSectionPort.getSection(locationId);
     }
 }

--- a/src/main/java/com/gamja/tiggle/reservation/domain/Seat.java
+++ b/src/main/java/com/gamja/tiggle/reservation/domain/Seat.java
@@ -13,7 +13,11 @@ public class Seat {
     private Location location;
     private Grade grade;
     private Long sectionId;
-    private ReservationType status;
+
+    private String row;
     private int seatNumber;
+    private Boolean active;
+
+    private ReservationType status;
     private Boolean available;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/domain/Section.java
+++ b/src/main/java/com/gamja/tiggle/reservation/domain/Section.java
@@ -11,4 +11,7 @@ public class Section {
     private Long locationId;
     private String sectionName;
     private Long gradeId;
+
+    private int rowCount; // 행
+    private int columnCount; // 열
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,371 +1,219 @@
-INSERT INTO tiggle.grade (grade_name)
-VALUES ('VIP');
-INSERT INTO tiggle.grade (grade_name)
-VALUES ('S');
-INSERT INTO tiggle.grade (grade_name)
-VALUES ('A');
-INSERT INTO tiggle.location (location_name)
-VALUES ('올림픽공원 올림픽 홀');
-INSERT INTO tiggle.location (location_name)
-VALUES ('인천아시아드 주경기장');
-INSERT INTO tiggle.location (location_name)
-VALUES ('서울랜드');
-INSERT INTO tiggle.location (location_name)
-VALUES ('고척 스카이돔');
-INSERT INTO tiggle.location (location_name)
-VALUES ('플러스 씨어터');
-INSERT INTO tiggle.location (location_name)
-VALUES ('대학로 TOM 관');
-INSERT INTO tiggle.location (location_name)
-VALUES ('대학로 자유극장');
-INSERT INTO tiggle.category (category_name)
-VALUES ('뮤지컬');
-INSERT INTO tiggle.category (category_name)
-VALUES ('콘서트');
-INSERT INTO tiggle.category (category_name)
-VALUES ('연극');
+-- grade 테이블
+INSERT INTO tiggle.grade (grade_name) VALUES
+                                          ('VIP'),
+                                          ('S'),
+                                          ('A');
+-- location 테이블
+INSERT INTO tiggle.location (location_name) VALUES
+                                                ('올림픽공원 올림픽 홀'),
+                                                ('인천아시아드 주경기장'),
+                                                ('서울랜드'),
+                                                ('고척 스카이돔'),
+                                                ('플러스 씨어터'),
+                                                ('대학로 TOM 관'),
+                                                ('대학로 자유극장');
+-- category 테이블
+INSERT INTO tiggle.category (category_name) VALUES
+                                                ('뮤지컬'),
+                                                ('콘서트'),
+                                                ('연극');
+-- program 테이블
 INSERT INTO tiggle.program (id, age, program_end_date, program_info, program_name, program_start_date,
-                            reservation_open_date, runtime, category_id, location_id)
-VALUES (null, 14, '2024-09-29 16:24:34.000000', '뮤지컬 〈시카고〉', '시카고', '2024-06-27 16:25:34.000000',
-        '2024-05-01 16:25:46.000000', 145, 1, 1);
-INSERT INTO tiggle.program (id, age, program_end_date, program_info, program_name, program_start_date,
-                            reservation_open_date, runtime, category_id, location_id)
-VALUES (null, 12, '2024-10-31 19:00:00.000000', '뮤지컬 〈레 미제라블〉', '레 미제라블', '2024-08-01 19:00:00.000000',
-        '2024-06-01 10:00:00.000000', 160, 1, 2);
-INSERT INTO tiggle.program (id, age, program_end_date, program_info, program_name, program_start_date,
-                            reservation_open_date, runtime, category_id, location_id)
-VALUES (null, 8, '2024-12-15 19:30:00.000000', '뮤지컬 〈라이온 킹〉', '라이온 킹', '2024-09-15 19:30:00.000000',
-        '2024-07-01 09:00:00.000000', 135, 1, 3);
-INSERT INTO tiggle.program (id, age, program_end_date, program_info, program_name, program_start_date,
-                            reservation_open_date, runtime, category_id, location_id)
-VALUES (null, 10, '2024-11-20 18:00:00.000000', '뮤지컬 〈위키드〉', '위키드', '2024-08-20 18:00:00.000000',
-        '2024-06-15 12:00:00.000000', 150, 1, 4);
-INSERT INTO tiggle.program (id, age, program_end_date, program_info, program_name, program_start_date,
-                            reservation_open_date, runtime, category_id, location_id)
-VALUES (null, 7, '2024-08-30 20:00:00.000000', '뮤지컬 〈캣츠〉', '캣츠', '2024-05-30 20:00:00.000000',
-        '2024-04-01 11:00:00.000000', 130, 1, 5);
-INSERT INTO tiggle.program (id, age, program_end_date, program_info, program_name, program_start_date,
-                            reservation_open_date, runtime, category_id, location_id)
-VALUES (null, 15, '2024-09-30 21:00:00.000000', '공연 〈베토벤 교향곡〉', '베토벤 교향곡', '2024-07-01 21:00:00.000000',
-        '2024-05-01 14:00:00.000000', 120, 2, 1);
-INSERT INTO tiggle.program (id, age, program_end_date, program_info, program_name, program_start_date,
-                            reservation_open_date, runtime, category_id, location_id)
-VALUES (null, 16, '2024-11-10 19:00:00.000000', '공연 〈모차르트 레퀴엠〉', '모차르트 레퀴엠', '2024-09-10 19:00:00.000000',
-        '2024-07-10 10:00:00.000000', 90, 2, 2);
-INSERT INTO tiggle.program (id, age, program_end_date, program_info, program_name, program_start_date,
-                            reservation_open_date, runtime, category_id, location_id)
-VALUES (null, 18, '2024-10-25 18:30:00.000000', '공연 〈바흐 무반주 첼로 모음곡〉', '바흐 무반주 첼로 모음곡', '2024-08-25 18:30:00.000000',
-        '2024-06-25 09:00:00.000000', 105, 2, 3);
-INSERT INTO tiggle.program (id, age, program_end_date, program_info, program_name, program_start_date,
-                            reservation_open_date, runtime, category_id, location_id)
-VALUES (null, 13, '2024-12-05 20:00:00.000000', '공연 〈쇼팽 피아노 협주곡〉', '쇼팽 피아노 협주곡', '2024-09-05 20:00:00.000000',
-        '2024-07-05 11:00:00.000000', 110, 2, 4);
-INSERT INTO tiggle.program (id, age, program_end_date, program_info, program_name, program_start_date,
-                            reservation_open_date, runtime, category_id, location_id)
-VALUES (null, 12, '2024-08-15 19:30:00.000000', '공연 〈비발디 사계〉', '비발디 사계', '2024-06-15 19:30:00.000000',
-        '2024-05-01 12:00:00.000000', 100, 2, 5);
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (100000, 1, 1); -- VIP
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (80000, 2, 1); -- S
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (60000, 3, 1); -- A
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (120000, 1, 2); -- VIP
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (90000, 2, 2); -- S
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (70000, 3, 2); -- A
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (110000, 1, 3); -- VIP
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (85000, 2, 3); -- S
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (65000, 3, 3); -- A
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (130000, 1, 4); -- VIP
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (95000, 2, 4); -- S
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (75000, 3, 4); -- A
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (90000, 1, 5); -- VIP
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (70000, 2, 5); -- S
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (50000, 3, 5); -- A
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (150000, 1, 6); -- VIP
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (110000, 2, 6); -- S
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (90000, 3, 6); -- A
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (140000, 1, 7); -- VIP
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (100000, 2, 7); -- S
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (80000, 3, 7); -- A
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (130000, 1, 8); -- VIP
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (95000, 2, 8); -- S
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (75000, 3, 8); -- A
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (120000, 1, 9); -- VIP
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (90000, 2, 9); -- S
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (70000, 3, 9); -- A
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (110000, 1, 10); -- VIP
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (85000, 2, 10); -- S
-INSERT INTO tiggle.program_grade (price, grade_id, program_id)
-VALUES (65000, 3, 10); -- A
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-06-28 19:00:00.000000', '2024-06-28 18:30:00.000000', 1, 1);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-06-29 19:00:00.000000', '2024-06-29 18:30:00.000000', 2, 1);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-06-30 19:00:00.000000', '2024-06-30 18:30:00.000000', 3, 1);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-08-02 19:00:00.000000', '2024-08-02 18:30:00.000000', 1, 2);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-08-03 19:00:00.000000', '2024-08-03 18:30:00.000000', 2, 2);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-08-04 19:00:00.000000', '2024-08-04 18:30:00.000000', 3, 2);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-09-16 19:30:00.000000', '2024-09-16 19:00:00.000000', 1, 1);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-09-17 19:30:00.000000', '2024-09-17 19:00:00.000000', 2, 1);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-09-18 19:30:00.000000', '2024-09-18 19:00:00.000000', 3, 1);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-08-21 18:00:00.000000', '2024-08-21 17:30:00.000000', 1, 1);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-08-22 18:00:00.000000', '2024-08-22 17:30:00.000000', 2, 1);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-08-23 18:00:00.000000', '2024-08-23 17:30:00.000000', 3, 1);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-05-31 20:00:00.000000', '2024-05-31 19:30:00.000000', 1, 1);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-06-01 20:00:00.000000', '2024-06-01 19:30:00.000000', 2, 1);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-06-02 20:00:00.000000', '2024-06-02 19:30:00.000000', 3, 1);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-07-02 21:00:00.000000', '2024-07-02 20:30:00.000000', 1, 2);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-07-03 21:00:00.000000', '2024-07-03 20:30:00.000000', 2, 2);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-07-04 21:00:00.000000', '2024-07-04 20:30:00.000000', 3, 2);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-09-11 19:00:00.000000', '2024-09-11 18:30:00.000000', 1, 2);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-09-12 19:00:00.000000', '2024-09-12 18:30:00.000000', 2, 2);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-09-13 19:00:00.000000', '2024-09-13 18:30:00.000000', 3, 2);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-08-26 18:30:00.000000', '2024-08-26 18:00:00.000000', 1, 2);
-INSERT INTO tiggle.times (date, limit_enter_time, round, program_id)
-VALUES ('2024-08-27 18:30:00.000000', '2024-08-27 18:00:00.000000', 2, 2);
-INSERT INTO tiggle.section (section_name, grade_id, location_id)
-VALUES ('A구역', 1, 1);
-INSERT INTO tiggle.section (section_name, grade_id, location_id)
-VALUES ('B구역', 2, 1);
-INSERT INTO tiggle.section (section_name, grade_id, location_id)
-VALUES ('C구역', 3, 1);
-INSERT INTO tiggle.section (section_name, grade_id, location_id)
-VALUES ('D구역', 1, 2);
-INSERT INTO tiggle.section (section_name, grade_id, location_id)
-VALUES ('E구역', 2, 2);
-INSERT INTO tiggle.section (section_name, grade_id, location_id)
-VALUES ('F구역', 3, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (1, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (2, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (3, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (4, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (5, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (6, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (7, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (8, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (9, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (10, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (11, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (12, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (13, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (14, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (15, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (16, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (17, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (18, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (19, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (20, 1);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (1, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (2, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (3, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (4, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (5, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (6, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (7, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (8, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (9, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (10, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (11, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (12, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (13, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (14, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (15, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (16, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (17, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (18, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (19, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (20, 2);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (1, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (2, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (3, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (4, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (5, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (6, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (7, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (8, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (9, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (10, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (11, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (12, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (13, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (14, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (15, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (16, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (17, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (18, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (19, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (20, 3);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (1, 4);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (2, 4);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (3, 4);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (4, 4);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (5, 4);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (6, 4);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (7, 4);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (8, 4);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (9, 4);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (10, 4);
-INSERT INTO tiggle.seat (seat_number, section_id)
-VALUES (11, 4);
-INSERT INTO tiggle.user (created_at, email, enable, login_type, name, password, phone_number, region_1depth_name,
-                         region_2depth_name, region_3depth_name, region_4depth_name, role, status, verified_at)
-VALUES ('2024-07-15 15:11:24.000000', 'test@gmail.com', true, null, '홍길동', 'qwer1234', '01012341234', null, null, null,
-        null, 'ADMIN', true, '2024-07-16 15:12:19.000000');
-INSERT INTO tiggle.user (created_at, email, enable, login_type, name, password, phone_number, region_1depth_name,
-                         region_2depth_name, region_3depth_name, region_4depth_name, role, status, verified_at)
-VALUES ('2024-07-15 15:14:00.000000', 'test02@gmail.com', true, null, '홍이동', 'qwer1234', '01012341234', null, null,
-        null, null, 'ADMIN', true, '2024-07-17 15:13:19.000000');
-INSERT INTO tiggle.reservation (available, pay_method, request_limit, status, ticket_number, total_price, program_id,
-                                seat_id, times_id, user_id)
-VALUES (DEFAULT, null, null, 'COMPLETED', '20240721130104-g1az', 100000, 4, 3, 1, 1);
-INSERT INTO tiggle.reservation (available, pay_method, request_limit, status, ticket_number, total_price, program_id,
-                                seat_id, times_id, user_id)
-VALUES (DEFAULT, null, null, 'IN_PROGRESS', '20240721130213-fe12', 80000, 4, 4, 1, 2);
-INSERT INTO tiggle.reservation (available, request_limit, total_price, created_at, modified_at, program_id, seat_id,
-                                times_id, user_id, pay_method, ticket_number, status)
-VALUES (DEFAULT, 5, 100000, '2024-07-23 16:58:35.000000', null, 1, 1, 1, 1, null, '20240721140511-fdsz', null);
+                            reservation_open_date, runtime, category_id, location_id) VALUES
+                                                                                          (null, 14, '2024-09-29 16:24:34.000000', '뮤지컬 〈시카고〉', '시카고', '2024-06-27 16:25:34.000000',
+                                                                                           '2024-05-01 16:25:46.000000', 145, 1, 1),
+                                                                                          (null, 12, '2024-10-31 19:00:00.000000', '뮤지컬 〈레 미제라블〉', '레 미제라블', '2024-08-01 19:00:00.000000',
+                                                                                           '2024-06-01 10:00:00.000000', 160, 1, 2),
+                                                                                          (null, 8, '2024-12-15 19:30:00.000000', '뮤지컬 〈라이온 킹〉', '라이온 킹', '2024-09-15 19:30:00.000000',
+                                                                                           '2024-07-01 09:00:00.000000', 135, 1, 3),
+                                                                                          (null, 10, '2024-11-20 18:00:00.000000', '뮤지컬 〈위키드〉', '위키드', '2024-08-20 18:00:00.000000',
+                                                                                           '2024-06-15 12:00:00.000000', 150, 1, 4),
+                                                                                          (null, 7, '2024-08-30 20:00:00.000000', '뮤지컬 〈캣츠〉', '캣츠', '2024-05-30 20:00:00.000000',
+                                                                                           '2024-04-01 11:00:00.000000', 130, 1, 5),
+                                                                                          (null, 15, '2024-09-30 21:00:00.000000', '공연 〈베토벤 교향곡〉', '베토벤 교향곡', '2024-07-01 21:00:00.000000',
+                                                                                           '2024-05-01 14:00:00.000000', 120, 2, 1),
+                                                                                          (null, 16, '2024-11-10 19:00:00.000000', '공연 〈모차르트 레퀴엠〉', '모차르트 레퀴엠', '2024-09-10 19:00:00.000000',
+                                                                                           '2024-07-10 10:00:00.000000', 90, 2, 2),
+                                                                                          (null, 18, '2024-10-25 18:30:00.000000', '공연 〈바흐 무반주 첼로 모음곡〉', '바흐 무반주 첼로 모음곡', '2024-08-25 18:30:00.000000',
+                                                                                           '2024-06-25 09:00:00.000000', 105, 2, 3),
+                                                                                          (null, 13, '2024-12-05 20:00:00.000000', '공연 〈쇼팽 피아노 협주곡〉', '쇼팽 피아노 협주곡', '2024-09-05 20:00:00.000000',
+                                                                                           '2024-07-05 11:00:00.000000', 110, 2, 4),
+                                                                                          (null, 12, '2024-08-15 19:30:00.000000', '공연 〈비발디 사계〉', '비발디 사계', '2024-06-15 19:30:00.000000',
+                                                                                           '2024-05-01 12:00:00.000000', 100, 2, 5);
+INSERT INTO tiggle.section (location_id, grade_id, section_name, row_count, column_count) VALUES
+                                                                                       (1, 1, 'Square', 5, 5),
+                                                                                       (1, 1, 'Rectangle', 5, 3),
+                                                                                       (1, 1, 'Cross', 5, 5),
+                                                                                       (1, 1, 'L Shape', 4, 4),
+                                                                                       (1, 1, 'Inverted L Shape', 4, 4);
+-- program_grade 테이블
+INSERT INTO tiggle.program_grade (price, grade_id, program_id) VALUES
+                                                                   (100000, 1, 1),
+                                                                   (80000, 2, 1),
+                                                                   (60000, 3, 1),
+                                                                   (120000, 1, 2),
+                                                                   (90000, 2, 2),
+                                                                   (70000, 3, 2),
+                                                                   (110000, 1, 3),
+                                                                   (85000, 2, 3),
+                                                                   (65000, 3, 3),
+                                                                   (130000, 1, 4),
+                                                                   (95000, 2, 4),
+                                                                   (75000, 3, 4),
+                                                                   (90000, 1, 5),
+                                                                   (70000, 2, 5),
+                                                                   (50000, 3, 5),
+                                                                   (150000, 1, 6),
+                                                                   (110000, 2, 6),
+                                                                   (90000, 3, 6),
+                                                                   (140000, 1, 7),
+                                                                   (100000, 2, 7),
+                                                                   (80000, 3, 7),
+                                                                   (130000, 1, 8),
+                                                                   (95000, 2, 8),
+                                                                   (75000, 3, 8),
+                                                                   (120000, 1, 9),
+                                                                   (90000, 2, 9),
+                                                                   (70000, 3, 9),
+                                                                   (110000, 1, 10),
+                                                                   (85000, 2, 10),
+                                                                   (65000, 3, 10);
+-- times 테이블
+INSERT INTO tiggle.times (date, limit_enter_time, round, program_id) VALUES
+                                                                         ('2024-06-28 19:00:00.000000', '2024-06-28 18:30:00.000000', 1, 1),
+                                                                         ('2024-06-29 19:00:00.000000', '2024-06-29 18:30:00.000000', 2, 1),
+                                                                         ('2024-06-30 19:00:00.000000', '2024-06-30 18:30:00.000000', 3, 1),
+                                                                         ('2024-08-02 19:00:00.000000', '2024-08-02 18:30:00.000000', 1, 2),
+                                                                         ('2024-08-03 19:00:00.000000', '2024-08-03 18:30:00.000000', 2, 2),
+                                                                         ('2024-08-04 19:00:00.000000', '2024-08-04 18:30:00.000000', 3, 2),
+                                                                         ('2024-09-16 19:30:00.000000', '2024-09-16 19:00:00.000000', 1, 1),
+                                                                         ('2024-09-17 19:30:00.000000', '2024-09-17 19:00:00.000000', 2, 1),
+                                                                         ('2024-09-18 19:30:00.000000', '2024-09-18 19:00:00.000000', 3, 1),
+                                                                         ('2024-08-21 18:00:00.000000', '2024-08-21 17:30:00.000000', 1, 1),
+                                                                         ('2024-08-22 18:00:00.000000', '2024-08-22 17:30:00.000000', 2, 1),
+                                                                         ('2024-08-23 18:00:00.000000', '2024-08-23 17:30:00.000000', 3, 1),
+                                                                         ('2024-07-01 20:00:00.000000', '2024-07-01 19:30:00.000000', 1, 2),
+                                                                         ('2024-07-02 20:00:00.000000', '2024-07-02 19:30:00.000000', 2, 2),
+                                                                         ('2024-07-03 20:00:00.000000', '2024-07-03 19:30:00.000000', 3, 2),
+                                                                         ('2024-09-26 18:30:00.000000', '2024-09-26 18:00:00.000000', 1, 1),
+                                                                         ('2024-09-27 18:30:00.000000', '2024-09-27 18:00:00.000000', 2, 1),
+                                                                         ('2024-09-28 18:30:00.000000', '2024-09-28 18:00:00.000000', 3, 1),
+                                                                         ('2024-08-24 19:30:00.000000', '2024-08-24 19:00:00.000000', 1, 2),
+                                                                         ('2024-08-25 19:30:00.000000', '2024-08-25 19:00:00.000000', 2, 2),
+                                                                         ('2024-08-26 19:30:00.000000', '2024-08-26 19:00:00.000000', 3, 2),
+                                                                         ('2024-12-07 20:00:00.000000', '2024-12-07 19:30:00.000000', 1, 3),
+                                                                         ('2024-12-08 20:00:00.000000', '2024-12-08 19:30:00.000000', 2, 3),
+                                                                         ('2024-12-09 20:00:00.000000', '2024-12-09 19:30:00.000000', 3, 3),
+                                                                         ('2024-09-20 18:00:00.000000', '2024-09-20 17:30:00.000000', 1, 4),
+                                                                         ('2024-09-21 18:00:00.000000', '2024-09-21 17:30:00.000000', 2, 4),
+                                                                         ('2024-09-22 18:00:00.000000', '2024-09-22 17:30:00.000000', 3, 4),
+                                                                         ('2024-11-30 19:00:00.000000', '2024-11-30 18:30:00.000000', 1, 5),
+                                                                         ('2024-12-01 19:00:00.000000', '2024-12-01 18:30:00.000000', 2, 5),
+                                                                         ('2024-12-02 19:00:00.000000', '2024-12-02 18:30:00.000000', 3, 5);
+INSERT INTO tiggle.seat (section_id, seat_number, row, active) VALUES
+-- Square
+(1, 1, 'A', true),
+(1, 2, 'A', true),
+(1, 3, 'A', true),
+(1, 4, 'A', true),
+(1, 5, 'A', true),
+(1, 1, 'B', true),
+(1, 2, 'B', true),
+(1, 3, 'B', true),
+(1, 4, 'B', true),
+(1, 5, 'B', true),
+(1, 1, 'C', true),
+(1, 2, 'C', true),
+(1, 3, 'C', true),
+(1, 4, 'C', true),
+(1, 5, 'C', true),
+(1, 1, 'D', true),
+(1, 2, 'D', true),
+(1, 3, 'D', true),
+(1, 4, 'D', true),
+(1, 5, 'D', true),
+(1, 1, 'E', true),
+(1, 2, 'E', true),
+(1, 3, 'E', true),
+(1, 4, 'E', true),
+(1, 5, 'E', true),
 
-INSERT INTO tiggle.reservation (available, request_limit, total_price, created_at, modified_at, program_id, seat_id,
-                                times_id, user_id, pay_method, ticket_number, status)
-VALUES (DEFAULT, 5, 100000, '2024-07-23 16:58:36.000000', null, 1, 2, 1, 1, null, '20240721130223-qe14', null);
+-- Rectangle
+(2, 1, 'A', true),
+(2, 2, 'A', true),
+(2, 3, 'A', true),
+(2, 4, 'A', false),
+(2, 5, 'A', false),
+(2, 1, 'B', true),
+(2, 2, 'B', true),
+(2, 3, 'B', true),
+(2, 4, 'B', false),
+(2, 5, 'B', false),
+(2, 1, 'C', true),
+(2, 2, 'C', true),
+(2, 3, 'C', true),
+(2, 4, 'C', false),
+(2, 5, 'C', false),
 
-INSERT INTO tiggle.reservation (available, request_limit, total_price, created_at, modified_at, program_id, seat_id,
-                                times_id, user_id, pay_method, ticket_number, status)
-VALUES (DEFAULT, 5, 100000, '2024-07-23 16:58:37.000000', null, 1, 3, 1, 2, null, '20240721130232-fcgh', null);
+-- Cross
+(3, 1, 'A', false),
+(3, 2, 'A', false),
+(3, 3, 'A', true),
+(3, 4, 'A', false),
+(3, 5, 'A', false),
+(3, 1, 'B', false),
+(3, 2, 'B', true),
+(3, 3, 'B', true),
+(3, 4, 'B', true),
+(3, 5, 'B', false),
+(3, 1, 'C', true),
+(3, 2, 'C', true),
+(3, 3, 'C', true),
+(3, 4, 'C', true),
+(3, 5, 'C', true),
+(3, 1, 'D', false),
+(3, 2, 'D', true),
+(3, 3, 'D', true),
+(3, 4, 'D', true),
+(3, 5, 'D', false),
+(3, 1, 'E', false),
+(3, 2, 'E', false),
+(3, 3, 'E', true),
+(3, 4, 'E', false),
+(3, 5, 'E', false),
 
-INSERT INTO tiggle.reservation (available, request_limit, total_price, created_at, modified_at, program_id, seat_id,
-                                times_id, user_id, pay_method, ticket_number, status)
-VALUES (DEFAULT, 5, 100000, '2024-07-23 16:58:38.000000', null, 1, 4, 1, 2, null, '20240721130211-fe23', null);
+-- L Shape
+(4, 1, 'A', true),
+(4, 2, 'A', true),
+(4, 3, 'A', true),
+(4, 4, 'A', true),
+(4, 1, 'B', true),
+(4, 2, 'B', true),
+(4, 3, 'B', true),
+(4, 4, 'B', false),
+(4, 1, 'C', true),
+(4, 2, 'C', true),
+(4, 3, 'C', false),
+(4, 4, 'C', false),
+(4, 1, 'D', true),
+(4, 2, 'D', false),
+(4, 3, 'D', false),
+(4, 4, 'D', false),
 
-INSERT INTO tiggle.reservation (available, request_limit, total_price, created_at, modified_at, program_id, seat_id,
-                                times_id, user_id, pay_method, ticket_number, status)
-VALUES (DEFAULT, 5, 100000, '2024-07-23 16:58:39.000000', null, 1, 5, 1, 2, null, '20240721130213-fe5f', null);
-
-INSERT INTO tiggle.reservation (available, request_limit, total_price, created_at, modified_at, program_id, seat_id,
-                                times_id, user_id, pay_method, ticket_number, status)
-VALUES (DEFAULT, 5, 100000, '2024-07-23 16:58:40.000000', null, 1, 6, 1, 2, null, '20240721130213-fea2', null);
-
-INSERT INTO tiggle.reservation (available, request_limit, total_price, created_at, modified_at, program_id, seat_id,
-                                times_id, user_id, pay_method, ticket_number, status)
-VALUES (DEFAULT, 5, 100000, '2024-07-23 16:58:41.000000', null, 1, 7, 1, 2, null, '20240721130213-fd1d', null);
-
-INSERT INTO tiggle.reservation (available, request_limit, total_price, created_at, modified_at, program_id, seat_id,
-                                times_id, user_id, pay_method, ticket_number, status)
-VALUES (DEFAULT, 5, 100000, '2024-07-23 16:57:42.000000', null, 1, 8, 1, 2, null, '20240721130213-fexw', null);
+-- Inverted L Shape
+(5, 1, 'A', true),
+(5, 2, 'A', true),
+(5, 3, 'A', false),
+(5, 4, 'A', false),
+(5, 1, 'B', true),
+(5, 2, 'B', true),
+(5, 3, 'B', true),
+(5, 4, 'B', false),
+(5, 1, 'C', true),
+(5, 2, 'C', false),
+(5, 3, 'C', false),
+(5, 4, 'C', false),
+(5, 1, 'D', true),
+(5, 2, 'D', false),
+(5, 3, 'D', false),
+(5, 4, 'D', false);


### PR DESCRIPTION
## 연관된 이슈
#89 
<br>

## 작업 내용
- 구역Id, 프로그램id, 회차id를 입력받아 전체 좌석 정보를 조회하고 2차원 리스트로 가공해서 반환합니다. 
좌석의 존재여부(예약 여부가 아님)를 active로 표기했습니다.
- 예약 가능 좌석에 row 정보를 추가했습니다. 
- 그에 따라서 data.sql 도 변경했습니다. 
- 전체 좌석 예시
```
{
    "isSuccess": true,
    "code": 1000,
    "message": "요청에 성공하였습니다.",
    "result": [
        [ 
            {
                "seatId": 98,
                "row": "A",
                "seatNumber": 1,
                "active": true
            },
            {
                "seatId": 99,
                "row": "A",
                "seatNumber": 2,
                "active": true
            },
        ],
        [ 
            {
                "seatId": 103,
                "row": "B",
                "seatNumber": 1,
                "active": true
            },
        ],
    ]
}
```


<br> 

## 전달 사항
- 전체 좌석 정보에 예약 가능 여부까지 판단할지 생각해봐야합니다
+ 예약 가능 좌석 또한 2차원 배열로 가공해서 빈 좌석은 null로 처리하려다가 기존 방식 그대로 (List<좌석객체) 뒀습니다.
