### PR TITLE
[Feat] 좌석 조회 예외처리 추가 및 변경

### DIFF
--- a/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
+++ b/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
@@ -80,6 +80,9 @@ public enum BaseResponseStatus {
     NOT_FOUND_RESERVATION(false, 5001, "결제 정보가 존재하지 않습니다."),
     NOT_FOUND_TIMES(false, 5002, "회차 정보가 존재하지 않습니다."),
     NOT_FOUND_SEAT(false, 5003, "좌석 정보가 존재하지 않습니다."),
+    NOT_MATCH_ROW(false,5004,"행 정보가 일치하지 않습니다."),
+    NOT_MATCH_COLUMN(false,5004,"열 정보가 일치하지 않습니다."),
+    NOT_EXIST_TIMES(false,5005,"공연 회차정보가 존재하지 않습니다."),
 
 
     /**
@@ -101,7 +104,8 @@ public enum BaseResponseStatus {
      * 7000: 공연장, 구역, 좌석, 등급
      */
     NOT_FOUND_SECTION(false, 7000, "구역이 존재하지 않습니다."),
-    NOT_FOUND_PRICE(false, 7001, "등급별 가격 정보가 존재하지 않습니다."),
+    NOT_MATCH_SECTION(false, 7001, "해당 공연의 구역 정보가 존재하지 않습니다."),
+    NOT_FOUND_PRICE(false, 7002, "등급별 가격 정보가 존재하지 않습니다."),
 
     /**
      * 8000: 공통 에러

--- a/src/main/java/com/gamja/tiggle/program/adapter/out/persistence/JpaProgramRepository.java
+++ b/src/main/java/com/gamja/tiggle/program/adapter/out/persistence/JpaProgramRepository.java
@@ -10,5 +10,7 @@ public interface JpaProgramRepository extends JpaRepository<ProgramEntity, Long>
     @Query("SELECT p FROM ProgramEntity p JOIN FETCH p.categoryEntity c WHERE c.id = :categoryId")
     List<ProgramEntity> findAllByCategoryEntity (Long categoryId);
 
+    @Query("SELECT p.locationEntity.id FROM ProgramEntity p WHERE p.id = :programId")
+    Long findLocationIdById(Long programId);
 
 }

--- a/src/main/java/com/gamja/tiggle/program/adapter/out/persistence/ProgramPersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/program/adapter/out/persistence/ProgramPersistenceAdapter.java
@@ -147,8 +147,20 @@ public class ProgramPersistenceAdapter implements CreateProgramPort, ReadProgram
     }
 
     @Override
-    public boolean existProgram(Long id) {
-        return jpaProgramRepository.existsById(id);
+    public boolean existProgram(Long id) throws BaseException {
+        if(!jpaProgramRepository.existsById(id)){
+            throw new BaseException(BaseResponseStatus.NOT_FOUND_PROGRAM);
+        }
+        return true;
+    }
+
+    @Override
+    public Long getLocationId(Long programId) throws BaseException {
+        Long locationIdById = jpaProgramRepository.findLocationIdById(programId);
+        if (locationIdById == null){
+            throw new BaseException(BaseResponseStatus.NOT_FOUND_LOCATION_ID);
+        }
+        return locationIdById;
     }
 
 }

--- a/src/main/java/com/gamja/tiggle/program/application/port/out/ProgramPort.java
+++ b/src/main/java/com/gamja/tiggle/program/application/port/out/ProgramPort.java
@@ -1,5 +1,9 @@
 package com.gamja.tiggle.program.application.port.out;
 
+import com.gamja.tiggle.common.BaseException;
+
 public interface ProgramPort {
-    boolean existProgram(Long id);
+    boolean existProgram(Long id) throws BaseException;
+
+    Long getLocationId(Long programId) throws BaseException;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSeatController.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSeatController.java
@@ -37,7 +37,6 @@ public class GetSeatController {
             @RequestBody GetAllSeatRequest request,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
 
-        // TODO 조회된 회차의 구역이 아니라 다른 구역을 선택했을떄도 값이 출력, 예외처리해야함
         List<List<GetAllSeatResponse>> AllSeatResponse;
         try {
             List<List<Seat>> allSeat = getSeatUseCase.getAllSeat(toAllSeatCommand(request));

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSeatController.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSeatController.java
@@ -37,7 +37,7 @@ public class GetSeatController {
             @RequestBody GetAllSeatRequest request,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
 
-
+        // TODO 조회된 회차의 구역이 아니라 다른 구역을 선택했을떄도 값이 출력, 예외처리해야함
         List<List<GetAllSeatResponse>> AllSeatResponse;
         try {
             List<List<Seat>> allSeat = getSeatUseCase.getAllSeat(toAllSeatCommand(request));

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/GetSectionListResponse.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/GetSectionListResponse.java
@@ -11,7 +11,5 @@ public class GetSectionListResponse {
     private String sectionName;
     private Long gradeId;
 
-    private int rowCount;
-    private int columnCount;
 
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSectionAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetSectionAdapter.java
@@ -33,6 +33,13 @@ public class GetSectionAdapter implements GetSectionPort {
         return from(sectionEntity);
     }
 
+    @Override
+    public void correctSection(Long sectionId, Long locationId) throws BaseException {
+        if(!sectionRepository.existsByIdAndLocationEntityId(sectionId, locationId)){
+            throw new BaseException(BaseResponseStatus.NOT_MATCH_SECTION);
+        }
+    }
+
     private List<Section> from(List<SectionEntity> allByLocationId) {
         return allByLocationId.stream().map(sectionEntity ->
                 Section.builder()

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetTimesAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetTimesAdapter.java
@@ -19,7 +19,6 @@ public class GetTimesAdapter implements GetTimesPort {
 
     @Override
     public List<Times> getTimes(Long id) throws BaseException {
-        // TODO 회차가 없는 경우 예외
         List<TimesEntity> TimesList = timesRepository.findAllByProgramEntityId(id);
         if (TimesList.isEmpty()) {
             throw new BaseException(BaseResponseStatus.NOT_FOUND_TIMES);

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetTimesAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/GetTimesAdapter.java
@@ -27,6 +27,15 @@ public class GetTimesAdapter implements GetTimesPort {
         return getList(TimesList);
     }
 
+    @Override
+    public void verifyTimes(Long timesId, Long programId) throws BaseException {
+
+        if (!timesRepository.existsByProgramEntityIdAndId(programId, timesId)) {
+            throw new BaseException(BaseResponseStatus.NOT_EXIST_TIMES);
+        }
+
+    }
+
     private static List<Times> getList(List<TimesEntity> TimesList) {
         return TimesList.stream().map(timesEntity -> Times.builder()
                 .id(timesEntity.getId())

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/SectionRepository.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/SectionRepository.java
@@ -9,4 +9,6 @@ public interface SectionRepository extends JpaRepository<SectionEntity, Long> {
 
     // TODO locationENtity ID
     List<SectionEntity> findAllByLocationEntityId(Long id);
+
+    Boolean existsByIdAndLocationEntityId(Long sectionId, Long LocationId);
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/TimesRepository.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/TimesRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface TimesRepository extends JpaRepository<TimesEntity, Long> {
 
     List<TimesEntity> findAllByProgramEntityId(Long id);
+
+    Boolean existsByProgramEntityIdAndId(Long programId, Long TimesId);
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSectionPort.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSectionPort.java
@@ -9,4 +9,6 @@ public interface GetSectionPort {
 
     List<Section> getSection(Long id) throws BaseException;
     Section getRowColumn(Long id) throws BaseException;
+
+    void correctSection(Long sectionId, Long locationId) throws BaseException;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetTimesPort.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetTimesPort.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface GetTimesPort {
 
     List<Times> getTimes(Long id) throws BaseException;
+
+    void verifyTimes(Long timesId, Long programId) throws BaseException;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/service/VerifySeatService.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/service/VerifySeatService.java
@@ -28,7 +28,7 @@ public class VerifySeatService implements VerifySeatUseCase {
         //좌석 검증
         Seat seat = Seat.builder().id(command.getSeatId()).build();
         verifySeatPort.verifySeat(seat);
-        // TODO 유저 추가하는데 USER 도메인 없어서 주석
+        // TODO 유저 추가
 
         //검증했으면 예약 임시 저장
         String ticketNumber = getTicketNumber();

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -42,7 +42,7 @@ INSERT INTO tiggle.program (id, age, program_end_date, program_info, program_nam
                                                                                            '2024-05-01 12:00:00.000000', 100, 2, 5);
 INSERT INTO tiggle.section (location_id, grade_id, section_name, row_count, column_count) VALUES
                                                                                        (1, 1, 'Square', 5, 5),
-                                                                                       (1, 1, 'Rectangle', 5, 3),
+                                                                                       (1, 1, 'Rectangle', 5, 5),
                                                                                        (1, 1, 'Cross', 5, 5),
                                                                                        (1, 1, 'L Shape', 4, 4),
                                                                                        (1, 1, 'Inverted L Shape', 4, 4);


### PR DESCRIPTION
## 연관된 이슈
#89 
<br>

## 작업 내용
- 좌석 조회 예외처리 추가 및 변경
예외처리가 되어있지 않던 회차와 구역 검증 예외처리
서비스 레이어에서 예외처리된 로직을 어뎁터 레이어로 변경해서 중복 코드 제거, 명확하게 에러가 터진 위치 명시
서비스 레이어에서는 비즈니스 로직만 신경쓰고, 어뎁터 레이어에서는 데이터 관리만 
<br> 

## 전달 사항
