### PR TITLE
[Feat] 사용자 정보 조회 기능 api 생성 #104

### DIFF
--- a/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
+++ b/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
@@ -24,10 +24,11 @@ public enum BaseResponseStatus {
     /**
      * 2000: 유저
      */
-    NOT_FOUND_USER(false, 2000, "허가되지 않은 사용자 접근 입니다."),
+    NOT_FOUND_USER(false, 2000, "허가되지 않은 사용자 접근 혹은 유저 정보가 존재하지 않습니다."),
     USER_EMPTY_EMAIL(false, 2001, "이메일 등록란은 필수 항목입니다."),
     USER_EMPTY_NAME(false, 2002, "이름 등록란은 필수 항목입니다."),
     USER_EMPTY_PASSWORD(false, 2003, "패스워드 입력란은 필수 항목입니다."),
+
 
 
     /**

--- a/src/main/java/com/gamja/tiggle/user/adapter/in/web/MyPageInfoController.java
+++ b/src/main/java/com/gamja/tiggle/user/adapter/in/web/MyPageInfoController.java
@@ -1,0 +1,53 @@
+package com.gamja.tiggle.user.adapter.in.web;
+
+import com.fasterxml.jackson.databind.ser.Serializers;
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.common.BaseResponse;
+import com.gamja.tiggle.common.BaseResponseStatus;
+import com.gamja.tiggle.reservation.domain.Reservation;
+import com.gamja.tiggle.user.application.port.in.SearchUserUseCase;
+import com.gamja.tiggle.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@Tag(name = "myPage-info-controller")
+public class MyPageInfoController {
+    private final SearchUserUseCase searchUserUseCase;
+
+    public MyPageInfoController(SearchUserUseCase searchUserUseCase) {
+        this.searchUserUseCase = searchUserUseCase;
+    }
+
+    @Operation(summary = "마이페이지 내 정보 프론트 엔드 전달 api 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Successfully connecting my page", content = @Content(schema = @Schema(implementation = MyPageResponse.class))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    @GetMapping("/my-page")
+    public BaseResponse<User> myPage(Long userIdx) {
+        User user;
+        try {
+            user = searchUserUseCase.findById(userIdx);
+        } catch (BaseException e) {
+            return new BaseResponse(e.getStatus());
+        }
+        return new BaseResponse<>(user);
+    }
+}
+
+@Getter
+@Setter
+class MyPageResponse {
+    private String token;
+}

--- a/src/main/java/com/gamja/tiggle/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -1,11 +1,13 @@
 package com.gamja.tiggle.user.adapter.out.persistence;
 
 import com.gamja.tiggle.common.BaseException;
-import com.gamja.tiggle.user.application.port.out.EmailVerifyPort;
+import com.gamja.tiggle.common.BaseResponseStatus;
 import com.gamja.tiggle.user.application.port.out.UserPersistencePort;
 import com.gamja.tiggle.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -60,6 +62,28 @@ public class UserPersistenceAdapter implements UserPersistencePort {
         entity.createdAt();
 
         jpaUserRepository.save(entity);
+    }
+
+    @Override
+    public User searchUser(Long id) throws BaseException {
+        Optional<UserEntity> userEntity = jpaUserRepository.findById(id);
+        if (userEntity.isPresent()) {
+            return User.builder()
+                    .name(userEntity.get().getName())
+                    .email(userEntity.get().getEmail())
+                    .password(userEntity.get().getPassword())
+                    .loginType(userEntity.get().getLoginType())
+                    .status(userEntity.get().getStatus())
+                    .enable(userEntity.get().getEnable())
+                    .region_1depth_name(userEntity.get().getRegion_1depth_name())
+                    .region_2depth_name(userEntity.get().getRegion_2depth_name())
+                    .region_3depth_name(userEntity.get().getRegion_3depth_name())
+                    .region_4depth_name(userEntity.get().getRegion_4depth_name())
+                    .phoneNumber(userEntity.get().getPhoneNumber()).build();
+        }
+        else {
+            throw new BaseException(BaseResponseStatus.NOT_FOUND_USER);
+        }
     }
 }
 

--- a/src/main/java/com/gamja/tiggle/user/application/port/in/SearchUserUseCase.java
+++ b/src/main/java/com/gamja/tiggle/user/application/port/in/SearchUserUseCase.java
@@ -1,0 +1,12 @@
+package com.gamja.tiggle.user.application.port.in;
+
+import com.fasterxml.jackson.databind.ser.Serializers;
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.reservation.domain.Reservation;
+import com.gamja.tiggle.user.domain.User;
+
+import java.util.List;
+
+public interface SearchUserUseCase {
+    User findById(Long id) throws BaseException;
+}

--- a/src/main/java/com/gamja/tiggle/user/application/port/out/UserPersistencePort.java
+++ b/src/main/java/com/gamja/tiggle/user/application/port/out/UserPersistencePort.java
@@ -1,6 +1,7 @@
 package com.gamja.tiggle.user.application.port.out;
 
 import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.user.adapter.out.persistence.UserEntity;
 import com.gamja.tiggle.user.domain.User;
 import org.springframework.stereotype.Service;
 
@@ -9,5 +10,7 @@ public interface UserPersistencePort {
     void saveUser(User user) throws BaseException;
 
     void verifyUser(String email) throws BaseException;
+
+    User searchUser(Long id) throws BaseException;
 }
 

--- a/src/main/java/com/gamja/tiggle/user/application/service/SearchUserService.java
+++ b/src/main/java/com/gamja/tiggle/user/application/service/SearchUserService.java
@@ -1,0 +1,26 @@
+package com.gamja.tiggle.user.application.service;
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.user.application.port.in.SearchUserUseCase;
+import com.gamja.tiggle.user.application.port.in.SignupUserCommand;
+import com.gamja.tiggle.user.application.port.in.SignupUserUseCase;
+import com.gamja.tiggle.user.application.port.out.EmailVerifyPort;
+import com.gamja.tiggle.user.application.port.out.UserPersistencePort;
+import com.gamja.tiggle.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class SearchUserService implements SearchUserUseCase {
+    private final UserPersistencePort userPersistencePort;
+
+    @Override
+    public User findById(Long id) throws BaseException {
+        User user = userPersistencePort.searchUser(id);
+        return user;
+    }
+}


### PR DESCRIPTION
## 연관된 이슈
#104
<br>

## 작업 내용
/my-page를 통해 mypage에 접속 이후 제공 받은 userId를 통해 해당 사용자의 정보를 받을 수 있도록 한다.
또한 encoding된 비밀번호를 받도록 설정한다.
예외처리를 통해 BaseException 혹은 BaseResponse형태로 결과가 도출될 수 있도록 한다.
<br> 

## 전달 사항
