### PR TITLE
[Refactor] 예매 상세페이지 API 및 예매-결제 관계 설정 #128

### DIFF
--- a/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentEntity.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentEntity.java
@@ -33,7 +33,7 @@ public class PaymentEntity {
     //@JoinColumn(name = "user_id")
     //private User user;
 
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reservation_id")
     private ReservationEntity reservationEntity;
 

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/ReadReservationController.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/ReadReservationController.java
@@ -46,7 +46,15 @@ public class ReadReservationController {
                     reservation.getSeatInfo(),
                     reservation.getTotalPrice(),
                     reservation.getGradeName(),
-                    reservation.getStatus());
+                    reservation.getProgramName(),
+                    reservation.getProgramInfo(),
+                    reservation.getImageFiles(),
+                    reservation.getPayType(),
+                    reservation.getTicketPrice(),
+                    reservation.getUsePoint(),
+                    reservation.getStatus()
+            );
+
             // 성공 응답 반환
             return new BaseResponse<>(BaseResponseStatus.SUCCESS, response);
         } catch (BaseException e) {

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/ReadReservationResponse.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/ReadReservationResponse.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @Builder
@@ -24,6 +25,13 @@ public class ReadReservationResponse {
     private String seatInfo; // 좌석 정보 : A구역 1층 3열 N번
     private Integer totalPrice; // 가격 정보
     private String gradeName; // 좌석 등급
+
+    private String programName; // 공연 이름
+    private String programInfo; // 공연 정보
+    private List<String> imageFiles; // 이미지
+    private String payType; // 결제 방식
+    private Integer ticketPrice; // 티켓 가격
+    private Integer usePoint; // 포인트 사용
 
     @Enumerated(EnumType.STRING)
     private ReservationType status; // 예매 상태

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/ReservationEntity.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/ReservationEntity.java
@@ -2,6 +2,7 @@ package com.gamja.tiggle.reservation.adapter.out.persistence.Entity;
 
 import com.gamja.tiggle.exchange.adapter.out.persistence.ExchangeEntity;
 import com.gamja.tiggle.common.BaseEntity;
+import com.gamja.tiggle.payment.adapter.out.persistence.PaymentEntity;
 import com.gamja.tiggle.program.adapter.out.persistence.Entity.ProgramEntity;
 import com.gamja.tiggle.reservation.domain.type.ReservationType;
 import com.gamja.tiggle.user.adapter.out.persistence.UserEntity;
@@ -42,6 +43,9 @@ public class ReservationEntity extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "times_id")
     private TimesEntity timesEntity;
+
+    @OneToOne(mappedBy = "reservationEntity", fetch = FetchType.LAZY)
+    private PaymentEntity paymentEntity;
 
     private String ticketNumber;
     private Integer totalPrice;

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/ReadReservationPersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/ReadReservationPersistenceAdapter.java
@@ -29,6 +29,10 @@ public class ReadReservationPersistenceAdapter implements ReadReservationPort {
     @Override
     public Reservation readReservation(Reservation reservation) throws BaseException {
         ReservationEntity result = repository.findReservationWithDetails(reservation.getId());
+        List<String> imageFiles = result.getProgramEntity().getProgramImageEntities().stream()
+                .map(programImageEntity -> programImageEntity.getImgUrl())
+                .collect(Collectors.toList());
+
         Reservation reservations = Reservation.builder()
                 .ticketNumber(result.getTicketNumber())
                 .createdAt(result.getCreatedAt())
@@ -40,6 +44,12 @@ public class ReadReservationPersistenceAdapter implements ReadReservationPort {
                 .totalPrice(result.getTotalPrice())
                 .gradeName(result.getSeatEntity().getSectionEntity().getGradeEntity().getGradeName())
                 .status(result.getStatus())
+                .programName(result.getProgramEntity().getProgramName())
+                .programInfo(result.getProgramEntity().getProgramInfo())
+                .imageFiles(imageFiles)
+                .payType(result.getPaymentEntity().getPayType())
+                .ticketPrice(result.getPaymentEntity().getTicketPrice())
+                .usePoint(result.getPaymentEntity().getUsePoint())
                 .build();
         return reservations;
     }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/ReservationRepository.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/ReservationRepository.java
@@ -19,6 +19,7 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
             "JOIN FETCH r.seatEntity s " +
             "JOIN FETCH r.programEntity p " +
             "JOIN FETCH r.user u " +
+            "LEFT JOIN FETCH r.paymentEntity pe " +
             "WHERE r.id = :reservationId")
     ReservationEntity findReservationWithDetails(@Param("reservationId") Long reservationId);
 

--- a/src/main/java/com/gamja/tiggle/reservation/domain/Reservation.java
+++ b/src/main/java/com/gamja/tiggle/reservation/domain/Reservation.java
@@ -32,6 +32,11 @@ public class Reservation {
     private Integer refund;
 
     // 예매 받아올 값
+    private String programInfo; // 공연 정보
+    private String payType; // 결제 방식
+    private Integer ticketPrice; // 티켓 가격
+    private Integer usePoint; // 포인트 사용
+
     private LocalDateTime createdAt; // 예약 날짜
     private LocalDateTime date; // 공연 날짜
     private String locationName; // 공연장
@@ -42,5 +47,7 @@ public class Reservation {
     private LocalDateTime programStartDate; // 공연 날짜
     private LocalDateTime programEndDate;
     private List<String> imageFiles; // 이미지
+
+
 
 }


### PR DESCRIPTION
## 연관된 이슈
[Refactor] 예매 상세페이지 API 및 예매-결제 관계 설정 #128
<br>

## 작업 내용
예매 상세 페이지 response 받아오는 값 추가
예매 - 결제 일대일 관계 설정 
<br> 

## 전달 사항
결제가 reservation_id 를 갖도록 함