### PR TITLE
[Refactor] 마이페이지 예매 리스트 페이징처리 및 필터 조회 #133

### DIFF
--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/ReadReservationController.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/ReadReservationController.java
@@ -64,10 +64,14 @@ public class ReadReservationController {
     }
 
     @GetMapping("/myRead")
-    public BaseResponse<List<ReadMyReservationResponse>> myRead(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public BaseResponse<List<ReadMyReservationResponse>> myRead(@AuthenticationPrincipal CustomUserDetails customUserDetails,
+                                                                @RequestParam Integer page,
+                                                                @RequestParam Integer size) {
         User user = customUserDetails.getUser();
         ReadReservationCommand command = ReadReservationCommand.builder()
                 .user(user)
+                .page(page)
+                .size(size)
                 .build();
         try {
             List<Reservation> reservation = readReservationUseCase.myRead(command);

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/ReservationRepository.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/repositroy/ReservationRepository.java
@@ -1,8 +1,8 @@
 package com.gamja.tiggle.reservation.adapter.out.persistence.repositroy;
 
 import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.ReservationEntity;
-import com.gamja.tiggle.user.adapter.out.persistence.UserEntity;
-import com.gamja.tiggle.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -28,5 +28,5 @@ public interface ReservationRepository extends JpaRepository<ReservationEntity, 
             "JOIN FETCH r.programEntity p " +
             "JOIN FETCH r.user u " +
             "WHERE u.id = :userId")
-    List<ReservationEntity> findReservationsByUserId(@Param("userId") Long userId);
+    Page<ReservationEntity> findReservationsByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/in/ReadReservationCommand.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/in/ReadReservationCommand.java
@@ -9,4 +9,8 @@ import lombok.Getter;
 public class ReadReservationCommand {
     private User user;
     private Long reservationId;
+
+    // 페이징 처리 하려고
+    private Integer page;
+    private Integer size;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/out/ReadReservationPort.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/out/ReadReservationPort.java
@@ -1,15 +1,13 @@
 package com.gamja.tiggle.reservation.application.port.out;
-
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.ReservationEntity;
+import com.gamja.tiggle.reservation.application.port.in.ReadReservationCommand;
 import com.gamja.tiggle.reservation.domain.Reservation;
-import com.gamja.tiggle.user.domain.User;
-
 import java.util.List;
 
 
 public interface ReadReservationPort {
     ReservationEntity read(Long reservationId) throws BaseException;
     Reservation readReservation(Reservation reservation) throws  BaseException;
-    List<Reservation> myRead(User user) throws BaseException;
+    List<Reservation> myRead(ReadReservationCommand command) throws BaseException;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/service/ReadReservationService.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/service/ReadReservationService.java
@@ -31,6 +31,6 @@ public class ReadReservationService implements ReadReservationUseCase {
         if (user == null) {
             throw new BaseException(BaseResponseStatus.FAIL);
         }
-        return readReservationPort.myRead(user);
+        return readReservationPort.myRead(command);
     }
 }


### PR DESCRIPTION
## 연관된 이슈
[Refactor] 마이페이지 예매 리스트 페이징처리 및 필터 조회 #133
<br>

## 작업 내용
1. 티켓 예매 상태가 COMPLETED인 것만 출력하고, EXCHANGED인 것은 생략하기
2. 티켓 예매 페이지가 너무 한 번에 다 나와서 한 페이지에 4개씩만 나오도록 페이징 처리하기
<br> 

## 전달 사항
없습니다 ,, 다들 화이팅 ㅎ