### PR TITLE
[Feat] 외부 결제 API 실행을 위한 데이터 전송 API 구현

### DIFF
--- a/src/main/java/com/gamja/tiggle/payment/adapter/in/web/GetPayInfoController.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/in/web/GetPayInfoController.java
@@ -1,0 +1,53 @@
+package com.gamja.tiggle.payment.adapter.in.web;
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.common.BaseResponse;
+import com.gamja.tiggle.common.BaseResponseStatus;
+import com.gamja.tiggle.payment.adapter.in.web.response.GetPayInfoResponse;
+import com.gamja.tiggle.payment.application.port.in.CreatePaymentUseCase;
+import com.gamja.tiggle.payment.application.port.in.GetPayInfoUseCase;
+import com.gamja.tiggle.payment.domain.PayInfo;
+import com.gamja.tiggle.user.domain.CustomUserDetails;
+import com.gamja.tiggle.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/payment")
+@RequiredArgsConstructor
+public class GetPayInfoController {
+    private final GetPayInfoUseCase getPayInfoUseCase;
+
+    @GetMapping("/info")
+    @Operation(summary = "portone 입력 데이터 요청", description = "결제 API 이용을 위해 필요한 데이터를 전송해주는 API")
+    BaseResponse<GetPayInfoResponse> create(Long reservationId, @AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
+        User user = null;
+        PayInfo payInfo = null;
+        //CustomUserDetails 를 확인하여 로그인한 사용자의 정보와 Role을 확인
+        if (customUserDetails != null) {
+            user = customUserDetails.getUser();
+        } else {
+            return new BaseResponse(BaseResponseStatus.NOT_FOUND_USER);
+        }
+
+        try {
+            payInfo = getPayInfoUseCase.getReservation(reservationId);
+        } catch (BaseException e) {
+            return new BaseResponse(e.getStatus());
+        }
+        if (payInfo.getEmail4words().equals(user.getEmail())){
+            String email4words = (user.getEmail()).substring(0,4);
+            payInfo.setEmail4words(email4words);
+
+
+            return new BaseResponse<>(getPayInfoUseCase.makeResponse(payInfo));
+        }
+        else {
+            return new BaseResponse(BaseResponseStatus.INCORRECT_RESERVATION_DATA);
+        }
+    }
+}

--- a/src/main/java/com/gamja/tiggle/payment/adapter/in/web/request/CreatePaymentRequest.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/in/web/request/CreatePaymentRequest.java
@@ -1,5 +1,6 @@
 package com.gamja.tiggle.payment.adapter.in.web.request;
 
+import com.gamja.tiggle.payment.domain.PayType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +12,7 @@ import lombok.Setter;
 @AllArgsConstructor
 public class CreatePaymentRequest {
     private Long reservationId;
-    private String payType;
+    private PayType payType;
     private Integer ticketPrice;
     private Integer usePoint;
     private Integer fee;

--- a/src/main/java/com/gamja/tiggle/payment/adapter/in/web/response/GetPayInfoResponse.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/in/web/response/GetPayInfoResponse.java
@@ -1,0 +1,16 @@
+package com.gamja.tiggle.payment.adapter.in.web.response;
+
+import com.gamja.tiggle.payment.domain.PayType;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GetPayInfoResponse {
+    private String PAYMENTINFO;
+    private String ORDERNAME;
+    private Integer PRICE;
+    private PayType PAYMETHOD;
+}

--- a/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentEntity.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentEntity.java
@@ -1,5 +1,6 @@
 package com.gamja.tiggle.payment.adapter.out.persistence;
 
+import com.gamja.tiggle.payment.domain.PayType;
 import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.ReservationEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -26,7 +27,7 @@ public class PaymentEntity {
     private Integer ticketPrice;
     private Integer usePoint;
     private Integer fee;
-    private String payType;
+    private PayType payType;
     private Boolean verify;
 
     @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentPersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/payment/adapter/out/persistence/PaymentPersistenceAdapter.java
@@ -48,7 +48,9 @@ public class PaymentPersistenceAdapter implements PaymentPersistencePort {
         PaymentEntity result = jpaPaymentRepository.findByReservationEntity_Id(id);
         Optional<ReservationEntity> reservation = jpaReservationRepository.findById(id);
         Boolean reservationChk = false;
-        if ((reservation.get().getPayMethod() == result.getPayType())&&reservation.get().getStatus().equals("IN_PROGRESS")&&(reservation.get().getTotalPrice() == (result.getTicketPrice()+result.getFee()- result.getUsePoint()))){
+        if ((reservation.get().getPayType()) == result.getPayType()
+                &&reservation.get().getStatus().equals("IN_PROGRESS")
+                &&(reservation.get().getTotalPrice() == (result.getTicketPrice()+result.getFee()- result.getUsePoint()))){
             reservationChk = true;
         }
 
@@ -94,7 +96,7 @@ public class PaymentPersistenceAdapter implements PaymentPersistencePort {
                         .seatEntity(reservation.get().getSeatEntity())
                         .timesEntity(reservation.get().getTimesEntity())
                         .user(reservation.get().getUser())
-                        .payMethod(reservation.get().getPayMethod())
+                        .payType(reservation.get().getPayType())
                         .ticketNumber(reservation.get().getTicketNumber())
                         .totalPrice(reservation.get().getTotalPrice())
                         .status(ReservationType.EXCHANGED)
@@ -111,7 +113,7 @@ public class PaymentPersistenceAdapter implements PaymentPersistencePort {
                         .seatEntity(reservation.get().getSeatEntity())
                         .timesEntity(reservation.get().getTimesEntity())
                         .user(reservation.get().getUser())
-                        .payMethod(reservation.get().getPayMethod())
+                        .payType(reservation.get().getPayType())
                         .ticketNumber(reservation.get().getTicketNumber())
                         .totalPrice(reservation.get().getTotalPrice())
                         .status(ReservationType.COMPLETED)

--- a/src/main/java/com/gamja/tiggle/payment/application/port/in/CreatePaymentCommand.java
+++ b/src/main/java/com/gamja/tiggle/payment/application/port/in/CreatePaymentCommand.java
@@ -1,5 +1,6 @@
 package com.gamja.tiggle.payment.application.port.in;
 
+import com.gamja.tiggle.payment.domain.PayType;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,7 +12,7 @@ public class CreatePaymentCommand {
     private Integer ticketPrice;
     private Integer usePoint;
     private Integer fee;
-    private String payType;
+    private PayType payType;
     private Boolean verify;
 }
 

--- a/src/main/java/com/gamja/tiggle/payment/application/port/in/GetPayInfoUseCase.java
+++ b/src/main/java/com/gamja/tiggle/payment/application/port/in/GetPayInfoUseCase.java
@@ -1,0 +1,14 @@
+package com.gamja.tiggle.payment.application.port.in;
+
+import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.payment.adapter.in.web.response.GetPayInfoResponse;
+import com.gamja.tiggle.payment.domain.PayInfo;
+import com.gamja.tiggle.reservation.domain.Reservation;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface GetPayInfoUseCase {
+    PayInfo getReservation(Long id) throws BaseException;
+
+    GetPayInfoResponse makeResponse(PayInfo payInfo) throws BaseException;
+}

--- a/src/main/java/com/gamja/tiggle/payment/application/service/PGPaymentService.java
+++ b/src/main/java/com/gamja/tiggle/payment/application/service/PGPaymentService.java
@@ -2,21 +2,29 @@ package com.gamja.tiggle.payment.application.service;
 
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.common.BaseResponseStatus;
+import com.gamja.tiggle.payment.adapter.in.web.response.GetPayInfoResponse;
+import com.gamja.tiggle.payment.application.port.in.GetPayInfoUseCase;
 import com.gamja.tiggle.payment.application.port.in.VerifyPaymentCommand;
 import com.gamja.tiggle.payment.application.port.in.VerifyPaymentUseCase;
 import com.gamja.tiggle.payment.application.port.out.PaymentPersistencePort;
 import com.gamja.tiggle.payment.application.port.out.PortOnePort;
 import com.gamja.tiggle.payment.adapter.out.portOne.VerifyData;
+import com.gamja.tiggle.payment.domain.PayInfo;
+import com.gamja.tiggle.payment.domain.PayType;
 import com.gamja.tiggle.payment.domain.Payment;
+import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.ReservationEntity;
+import com.gamja.tiggle.reservation.application.port.out.ReadReservationPort;
+import com.gamja.tiggle.reservation.domain.type.ReservationType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 
 @Component
 @RequiredArgsConstructor
-public class PGPaymentService implements VerifyPaymentUseCase {
+public class PGPaymentService implements VerifyPaymentUseCase, GetPayInfoUseCase {
     private final PaymentPersistencePort paymentPersistencePort;
     private final PortOnePort portOnePort;
+    private final ReadReservationPort readReservationPort;
 
     @Override
     public String getToken() throws BaseException {
@@ -28,40 +36,67 @@ public class PGPaymentService implements VerifyPaymentUseCase {
     public void compareDB(VerifyPaymentCommand command, String accessToken) throws BaseException {
         String paymentId = command.getPaymentId();
         VerifyData data = portOnePort.findByPaymentId(accessToken, paymentId);
-        if (data == null){
+        if (data == null) {
             throw new BaseException(BaseResponseStatus.WRONG_PAYMENT_ID);
         }
 
         Boolean verified = false;
-         Payment paymentSearched = paymentPersistencePort.searchPayment(command.getReservationId());
+        Payment paymentSearched = paymentPersistencePort.searchPayment(command.getReservationId());
 
         // 정상 결제 검증
-        if (data.getStatus().equals("PAID")&&data.getPayId().equals(command.getPaymentId())&&data.getCanceled() == 0) {
-            if(data.getCountry().equals("KRW")&& data.getTotalPrice().equals(paymentSearched.getTicketPrice()+paymentSearched.getFee()-paymentSearched.getUsePoint())){
+        if (data.getStatus().equals("PAID") && data.getPayId().equals(command.getPaymentId()) && data.getCanceled() == 0) {
+            if (data.getCountry().equals("KRW") && data.getTotalPrice().equals(paymentSearched.getTicketPrice() + paymentSearched.getFee() - paymentSearched.getUsePoint())) {
                 verified = true;
-            }
-            else {
+            } else {
                 //결제 정상 진행 되었지만 데이터 이상,
                 //환불 요청
-                String PortOneError = portOnePort.cancel(accessToken ,paymentId, "결제 데이터 이상 확인");
+                String PortOneError = portOnePort.cancel(accessToken, paymentId, "결제 데이터 이상 확인");
                 System.out.println("PortOneError = " + PortOneError);
                 VerifyData cancelChk = portOnePort.findByPaymentId(accessToken, paymentId);
-                if(cancelChk.getStatus().equals("CANCELED")){
+                if (cancelChk.getStatus().equals("CANCELED")) {
                     //정상적으로 결제 취소
-                }
-                else {
+                } else {
                     throw new BaseException(BaseResponseStatus.FAIL_CANCELED_PAYMENT);
                 }
                 throw new BaseException(BaseResponseStatus.INCORRECT_DATA_CANCEL_SUCCESS);
             }
-        }
-
-        else {
+        } else {
             throw new BaseException(BaseResponseStatus.INCORRECT_PAYMENT_INFO);
         }
 
         if (verified) {
             paymentPersistencePort.verify(paymentSearched);
         }
+    }
+
+    @Override
+    public PayInfo getReservation(Long reservationId) throws BaseException {
+        ReservationEntity reservationEntity = readReservationPort.read(reservationId);
+        String email = reservationEntity.getUser().getEmail();
+        String ticketNumber = reservationEntity.getTicketNumber();
+        Integer ticketPrice = reservationEntity.getTotalPrice();
+        PayType payMethod = reservationEntity.getPayType();
+        ReservationType status = reservationEntity.getStatus();
+
+        return PayInfo.builder()
+                .Email4words(email)
+                .ticketNumber(ticketNumber)
+                .ticketPrice(ticketPrice)
+                .payMethod(payMethod)
+                .status(status).build();
+
+    }
+
+    @Override
+    public GetPayInfoResponse makeResponse(PayInfo payInfo) throws BaseException {
+        if (payInfo.getStatus().equals(ReservationType.IN_PROGRESS)){
+            return GetPayInfoResponse.builder()
+                    .PAYMENTINFO(payInfo.getTicketNumber()+"_"+payInfo.getEmail4words())
+                    .ORDERNAME("ticket")
+                    .PRICE(payInfo.getTicketPrice())
+                    .PAYMETHOD(payInfo.getPayMethod())
+                    .build();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/gamja/tiggle/payment/domain/PayInfo.java
+++ b/src/main/java/com/gamja/tiggle/payment/domain/PayInfo.java
@@ -1,0 +1,26 @@
+package com.gamja.tiggle.payment.domain;
+
+import com.gamja.tiggle.reservation.domain.type.ReservationType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PayInfo {
+    private String Email4words;
+    private Integer ticketPrice;
+    private String ticketNumber;
+    private PayType payMethod;
+    private ReservationType status;
+
+    public void setEmail4words(String email4words) {
+        Email4words = email4words;
+    }
+}
+

--- a/src/main/java/com/gamja/tiggle/payment/domain/PayType.java
+++ b/src/main/java/com/gamja/tiggle/payment/domain/PayType.java
@@ -1,0 +1,12 @@
+package com.gamja.tiggle.payment.domain;
+
+public enum PayType {
+    CARD,
+    VIRTUAL_ACCOUNT,
+    TRANSFER,
+    MOBILE,
+    GIFT_CERTIFICATE,
+    EASY_PAY,
+    PAYPAL,
+    ALIPAY
+}

--- a/src/main/java/com/gamja/tiggle/payment/domain/Payment.java
+++ b/src/main/java/com/gamja/tiggle/payment/domain/Payment.java
@@ -17,7 +17,7 @@ public class Payment {
     private Integer ticketPrice;
     private Integer usePoint;
     private Integer fee;
-    private String payType;
+    private PayType payType;
     private Boolean verify;
     private Date createdAt;
     private Date verifiedAt;

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/ReadReservationResponse.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/ReadReservationResponse.java
@@ -1,5 +1,6 @@
 package com.gamja.tiggle.reservation.adapter.in.web.response;
 
+import com.gamja.tiggle.payment.domain.PayType;
 import com.gamja.tiggle.reservation.domain.type.ReservationType;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -29,7 +30,7 @@ public class ReadReservationResponse {
     private String programName; // 공연 이름
     private String programInfo; // 공연 정보
     private List<String> imageFiles; // 이미지
-    private String payType; // 결제 방식
+    private PayType payType; // 결제 방식
     private Integer ticketPrice; // 티켓 가격
     private Integer usePoint; // 포인트 사용
 

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/ReservationEntity.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Entity/ReservationEntity.java
@@ -3,6 +3,7 @@ package com.gamja.tiggle.reservation.adapter.out.persistence.Entity;
 import com.gamja.tiggle.exchange.adapter.out.persistence.ExchangeEntity;
 import com.gamja.tiggle.common.BaseEntity;
 import com.gamja.tiggle.payment.adapter.out.persistence.PaymentEntity;
+import com.gamja.tiggle.payment.domain.PayType;
 import com.gamja.tiggle.program.adapter.out.persistence.Entity.ProgramEntity;
 import com.gamja.tiggle.reservation.domain.type.ReservationType;
 import com.gamja.tiggle.user.adapter.out.persistence.UserEntity;
@@ -54,7 +55,7 @@ public class ReservationEntity extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ReservationType status;
 
-    private String payMethod;
+    private PayType payType;
 
     // 예약 가능 True, 예약 불가능 false
     // 예약이 생성됐다는 건 예약 불가능 상태

--- a/src/main/java/com/gamja/tiggle/reservation/domain/Reservation.java
+++ b/src/main/java/com/gamja/tiggle/reservation/domain/Reservation.java
@@ -1,5 +1,6 @@
 package com.gamja.tiggle.reservation.domain;
 
+import com.gamja.tiggle.payment.domain.PayType;
 import com.gamja.tiggle.reservation.domain.type.ReservationType;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -22,7 +23,6 @@ public class Reservation {
     private Long timesId;
 
     private String ticketNumber;
-    private String payMethod;
     private Integer totalPrice;
 
     @Enumerated(EnumType.STRING)
@@ -33,7 +33,7 @@ public class Reservation {
 
     // 예매 받아올 값
     private String programInfo; // 공연 정보
-    private String payType; // 결제 방식
+    private PayType payType; // 결제 방식
     private Integer ticketPrice; // 티켓 가격
     private Integer usePoint; // 포인트 사용
     private Integer myPoint;  // 내 포인트


### PR DESCRIPTION
## 연관된 이슈
#151
<br>

## 작업 내용
 Reservastion, payment의 Entity 및 도메인에 존재하는 기존 String 타입의 paytype을 결제 API에 제공되는 enum 형식으로 전환
 Reservation과 User의 데이터를 가져오는 payInfo 데이터를 받아오는 메커니즘 구현
 받아온 payInfo를 검증을 통해 외부 결제 API의 양식에 맞는 데이터로 전환하여 response로 반환
검증 과정에서 발생하는 예외처리
<br> 

## 전달 사항
