### PR TITLE
[Feat] 교환 가능 좌석 조회 기능 구현 #159

### DIFF
--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSeatController.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/GetSeatController.java
@@ -7,6 +7,7 @@ import com.gamja.tiggle.common.annotation.WebAdapter;
 import com.gamja.tiggle.reservation.adapter.in.web.request.GetAllSeatRequest;
 import com.gamja.tiggle.reservation.adapter.in.web.request.GetAvailableSeatRequest;
 import com.gamja.tiggle.reservation.adapter.in.web.response.GetAllSeatResponse;
+import com.gamja.tiggle.reservation.adapter.in.web.response.GetAvailableExchangeSeatResponse;
 import com.gamja.tiggle.reservation.adapter.in.web.response.GetAvailableSeatResponse;
 import com.gamja.tiggle.reservation.application.port.in.GetAllSeatCommand;
 import com.gamja.tiggle.reservation.application.port.in.GetAvailableSeatCommand;
@@ -67,6 +68,23 @@ public class GetSeatController {
         return new BaseResponse<>(AllSeatResponse);
 
     }
+
+    @PostMapping("/available/exchange")
+    @Operation(summary = "교환 가능 좌석 조회", description = "교환 가능 좌석을 조회하는 API 입니다.")
+    public BaseResponse<List<List<GetAvailableExchangeSeatResponse>>> getAvailableExchange(
+        @RequestBody GetAllSeatRequest request,
+        @AuthenticationPrincipal CustomUserDetails customUserDetails) throws BaseException {
+
+            List<List<GetAvailableExchangeSeatResponse>> AvailableExchangeSeatResponse;
+            try {
+                List<List<Seat>> allSeat = getSeatUseCase.getAvailableExchangeSeat(toAllSeatCommand(request,customUserDetails.getUser()));
+                AvailableExchangeSeatResponse = getExchangeSeatResponse(allSeat);
+            } catch (BaseException e) {
+                return new BaseResponse<>(e.getStatus());
+            }
+            return new BaseResponse<>(AvailableExchangeSeatResponse);
+    }
+
 
 
 
@@ -149,4 +167,27 @@ public class GetSeatController {
                         .collect(Collectors.toList()))
                 .collect(Collectors.toList());
     }
+
+    public GetAvailableExchangeSeatResponse toGetAvailableExcnahgeSeatResponse(Seat seat) {
+        return GetAvailableExchangeSeatResponse.builder()
+                .seatId(seat.getId())
+                .seatNumber(seat.getSeatNumber())
+                .row(seat.getRow())
+                .active(seat.getActive())
+                .enable(seat.getEnable())
+                .reservationId(seat.getReservationId())
+                .price(seat.getPirce())
+                .build();
+    }
+
+    @NotNull
+    private List<List<GetAvailableExchangeSeatResponse>> getExchangeSeatResponse(List<List<Seat>> allSeat) {
+        return allSeat.stream()
+                .map(row -> row.stream()
+                        .filter(Objects::nonNull)
+                        .map(this::toGetAvailableExcnahgeSeatResponse)
+                        .collect(Collectors.toList()))
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/ReadReservationController.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/ReadReservationController.java
@@ -12,6 +12,7 @@ import com.gamja.tiggle.reservation.application.port.in.ReadReservationUseCase;
 import com.gamja.tiggle.reservation.domain.Reservation;
 import com.gamja.tiggle.user.domain.CustomUserDetails;
 import com.gamja.tiggle.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,6 +30,7 @@ public class ReadReservationController {
 
     // 예매 상세 정보
     @GetMapping("/read")
+    @Operation(summary = "예매 내역 조회", description = "ReservationId를 입력하여 예매 내역을 조회하는 API 입니다.")
     public BaseResponse<ReadReservationResponse> readReservation(@RequestParam Long reservationId) {
         try {
             // 커맨드 객체 생성
@@ -66,6 +68,7 @@ public class ReadReservationController {
 
 
     @GetMapping("/temporary")
+    @Operation(summary = "임시 예매 내역 조회", description = "ReservationId를 입력하여 진행중인 예매 내역을 조회하는 API 입니다.")
     public BaseResponse<ReadTemporaryReservationResponse> readTemporary(@RequestParam Long reservationId) {
         try {
 
@@ -96,6 +99,7 @@ public class ReadReservationController {
 
 
     @GetMapping("/myRead")
+    @Operation(summary = "예매내역 리스트 조회", description = "특정 사용자의 예매 내역들을 조회하는 API 입니다.")
     public BaseResponse<List<ReadMyReservationResponse>> myRead(@AuthenticationPrincipal CustomUserDetails customUserDetails,
                                                                 @RequestParam Integer page,
                                                                 @RequestParam Integer size) {

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/GetAvailableExchangeSeatResponse.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/in/web/response/GetAvailableExchangeSeatResponse.java
@@ -1,0 +1,18 @@
+package com.gamja.tiggle.reservation.adapter.in.web.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class GetAvailableExchangeSeatResponse {
+
+    private Long seatId;
+
+    private String row;
+    private int seatNumber;
+    private Boolean active;
+    private Boolean enable;
+    private Long reservationId;
+    private Integer price;
+}

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Response/GetAvailableExchangeSeatPersistenceResponse.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/Response/GetAvailableExchangeSeatPersistenceResponse.java
@@ -1,0 +1,28 @@
+package com.gamja.tiggle.reservation.adapter.out.persistence.Response;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class GetAvailableExchangeSeatPersistenceResponse {
+
+    private Long seatId;
+    private String row;
+    private int seatNumber;
+    private Boolean active;
+    private Boolean enable;
+    private Long reservationId;
+    private Integer price;
+
+    public GetAvailableExchangeSeatPersistenceResponse(Long id, String row, int seatNumber, Boolean active, Boolean enable, Long reservationId, Integer totalPrice) {
+        this.seatId = id;
+        this.row = row;
+        this.seatNumber = seatNumber;
+        this.active = active;
+        this.enable = enable;
+        this.reservationId = reservationId;
+        this.price = totalPrice;
+    }
+}

--- a/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/getSeatAdapter.java
+++ b/src/main/java/com/gamja/tiggle/reservation/adapter/out/persistence/getSeatAdapter.java
@@ -6,6 +6,7 @@ import com.gamja.tiggle.common.annotation.PersistenceAdapter;
 import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.ReservationEntity;
 import com.gamja.tiggle.reservation.adapter.out.persistence.Entity.SeatEntity;
 import com.gamja.tiggle.reservation.adapter.out.persistence.Response.GetAllSeatPersistentResponse;
+import com.gamja.tiggle.reservation.adapter.out.persistence.Response.GetAvailableExchangeSeatPersistenceResponse;
 import com.gamja.tiggle.reservation.adapter.out.persistence.Response.GetAvailableSeatResponse;
 import com.gamja.tiggle.reservation.adapter.out.persistence.repositroy.ReservationRepository;
 import com.gamja.tiggle.reservation.adapter.out.persistence.repositroy.SeatRepository;
@@ -134,6 +135,14 @@ public class getSeatAdapter implements GetSeatPort {
         return getSeatList(allSeat);
     }
 
+    @Override
+    public List<Seat> getAvailableExchang(Long programId, Long sectionId, Long timesId, Long userId) {
+        List<GetAvailableExchangeSeatPersistenceResponse> allSeat
+                = seatRepository.findAvailableExchange(programId, timesId, sectionId, userId);
+
+        return getExchangeSeatList(allSeat);
+    }
+
     @NotNull
     private static List<Seat> getSeatList(List<GetAllSeatPersistentResponse> allSeat) {
         return allSeat.stream().map(response ->
@@ -145,6 +154,23 @@ public class getSeatAdapter implements GetSeatPort {
                         .row(response.getRow())
                         .active(response.getActive())
                         .enable(response.getEnable())
+                        .build()
+        ).toList();
+    }
+
+    @NotNull
+    private static List<Seat> getExchangeSeatList(List<GetAvailableExchangeSeatPersistenceResponse> allSeat) {
+        return allSeat.stream().map(response ->
+                Seat
+                        .builder()
+                        .id(response.getSeatId())
+                        .enable(response.getEnable())
+                        .seatNumber(response.getSeatNumber())
+                        .row(response.getRow())
+                        .active(response.getActive())
+                        .enable(response.getEnable())
+                        .reservationId(response.getReservationId())
+                        .pirce(response.getPrice())
                         .build()
         ).toList();
     }

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetSeatUseCase.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/in/GetSeatUseCase.java
@@ -14,4 +14,5 @@ public interface GetSeatUseCase {
 
     List<List<Seat>> getAllSeatWithEnableExchange(GetAllSeatCommand command) throws BaseException;
 
+    List<List<Seat>> getAvailableExchangeSeat(GetAllSeatCommand command) throws BaseException;
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSeatPort.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/port/out/GetSeatPort.java
@@ -15,4 +15,6 @@ public interface GetSeatPort {
     List<Seat> getAllSeatWithEnable(Long programId, Long sectionId, Long timesId) throws BaseException;
 
     List<Seat> getAllSeatWithEnableExchange(Long programId, Long sectionId, Long timesId) throws BaseException;
+
+    List<Seat> getAvailableExchang(Long programId, Long sectionId, Long timesId, Long userId);
 }

--- a/src/main/java/com/gamja/tiggle/reservation/application/service/GetSeatService.java
+++ b/src/main/java/com/gamja/tiggle/reservation/application/service/GetSeatService.java
@@ -153,5 +153,41 @@ public class GetSeatService implements GetSeatUseCase {
         return ArraySeat;
     }
 
+    @Override
+    public List<List<Seat>> getAvailableExchangeSeat(GetAllSeatCommand command) throws BaseException {
+        List<Seat> allSeat = getSeatPort.getAvailableExchang(command.getProgramId(),
+                command.getSectionId(), command.getTimesId(), command.getUserId()
+        );
+
+        userPersistencePort.existUser(command.getUserId());
+        Long locationId = programPort.getLocationId(command.getProgramId());
+        programPort.existProgram(command.getProgramId());
+        timesPort.verifyTimes(command.getTimesId(), command.getProgramId());
+        sectionPort.correctSection(command.getSectionId(), locationId);
+
+        Section section = sectionPort.getRowColumn(command.getSectionId());
+        int rowCount = section.getRowCount();
+        int columnCount = section.getColumnCount();
+        List<List<Seat>> ArraySeat = new ArrayList<>();
+
+        for (int i = 0; i < rowCount; i++) {
+            ArraySeat.add(new ArrayList<>(Collections.nCopies(columnCount, null)));
+        }
+
+        for (Seat seat : allSeat) {
+            int rowIndex = seat.getRow().charAt(0) - 'A';
+            int colIndex = seat.getSeatNumber() - 1;
+
+            if (colIndex >= columnCount) throw new BaseException(BaseResponseStatus.NOT_MATCH_ROW);
+
+            if (rowIndex >= rowCount) throw new BaseException(BaseResponseStatus.NOT_MATCH_COLUMN);
+
+            ArraySeat.get(rowIndex).set(colIndex, seat);
+        }
+
+
+        return ArraySeat;
+    }
+
 
 }

--- a/src/main/java/com/gamja/tiggle/reservation/domain/Seat.java
+++ b/src/main/java/com/gamja/tiggle/reservation/domain/Seat.java
@@ -20,4 +20,7 @@ public class Seat {
 
     private ReservationType status;
     private Boolean enable;
+
+    private Long reservationId;
+    private Integer pirce;
 }

--- a/src/main/java/com/gamja/tiggle/user/adapter/in/web/AuthController.java
+++ b/src/main/java/com/gamja/tiggle/user/adapter/in/web/AuthController.java
@@ -3,6 +3,7 @@ package com.gamja.tiggle.user.adapter.in.web;
 import com.gamja.tiggle.common.BaseResponse;
 import com.gamja.tiggle.user.adapter.in.web.response.ValidationResponse;
 import com.gamja.tiggle.user.domain.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.web.bind.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     @GetMapping("")
+    @Operation(summary = "유효성 검증", description = "로그인 한 사용자인지 검증하는 API 입니다.")
     public BaseResponse<ValidationResponse> myPage(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Boolean isLogin = null;
 


### PR DESCRIPTION
## 연관된 이슈
#159 
<br>

## 작업 내용
- 교환 가능한 좌석을 반환하는 기능을 구현했다.
- 이미 예매된 좌석에만 교환 요청을 보낼 수 있으며, 자신이 구매한 좌석에는 교환 요청을 보낼 수 없도록 구현했다.

<br> 

## 전달 사항
