### PR TITLE
[Feat] 회원가입 이메일 중복 체크 #162

### DIFF
--- a/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
+++ b/src/main/java/com/gamja/tiggle/common/BaseResponseStatus.java
@@ -28,8 +28,8 @@ public enum BaseResponseStatus {
     USER_EMPTY_EMAIL(false, 2001, "이메일 등록란은 필수 항목입니다."),
     USER_EMPTY_NAME(false, 2002, "이름 등록란은 필수 항목입니다."),
     USER_EMPTY_PASSWORD(false, 2003, "패스워드 입력란은 필수 항목입니다."),
+    EXISTED_EMAIL(false,2004,"이미 가입된 이메일(아이디)입니다."),
     POINT_NOT_ENOUGH(false, 2101, "소유 포인트 보다 높은 포인트는 사용할 수 없습니다."),
-
 
 
     /**

--- a/src/main/java/com/gamja/tiggle/user/adapter/in/web/SignupUserController.java
+++ b/src/main/java/com/gamja/tiggle/user/adapter/in/web/SignupUserController.java
@@ -4,7 +4,9 @@ package com.gamja.tiggle.user.adapter.in.web;
 import com.gamja.tiggle.common.BaseException;
 import com.gamja.tiggle.common.BaseResponse;
 import com.gamja.tiggle.common.BaseResponseStatus;
+import com.gamja.tiggle.user.adapter.in.web.request.DuplicatedEmailRequest;
 import com.gamja.tiggle.user.adapter.in.web.request.SignupUserRequest;
+import com.gamja.tiggle.user.application.port.in.DuplicatedEmailCommand;
 import com.gamja.tiggle.user.application.port.in.SignupUserCommand;
 import com.gamja.tiggle.user.application.port.in.SignupUserUseCase;
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,9 +32,9 @@ public class SignupUserController {
             return new BaseResponse<>(USER_EMPTY_EMAIL);
         }
         if (request.getName() == null) {
-           return new BaseResponse<>(USER_EMPTY_NAME);
-       }
-        if(request.getPassword() == null) {
+            return new BaseResponse<>(USER_EMPTY_NAME);
+        }
+        if (request.getPassword() == null) {
             return new BaseResponse<>(USER_EMPTY_PASSWORD);
         }
 
@@ -56,4 +58,10 @@ public class SignupUserController {
         return new BaseResponse(BaseResponseStatus.SUCCESS);
     }
 
+    @PostMapping("/duplicatedEmail")
+    public BaseResponse<Boolean> duplicatedEmail(@RequestBody DuplicatedEmailRequest request) {
+        Boolean result = signupUserUseCase.duplicatedEmail(DuplicatedEmailCommand
+                .builder().email(request.getEmail()).build());
+        return new BaseResponse<>(result);
+    }
 }

--- a/src/main/java/com/gamja/tiggle/user/adapter/in/web/VerifyUserController.java
+++ b/src/main/java/com/gamja/tiggle/user/adapter/in/web/VerifyUserController.java
@@ -35,4 +35,6 @@ public class VerifyUserController {
         return new BaseResponse(BaseResponseStatus.SUCCESS);
     }
 
+
+
 }

--- a/src/main/java/com/gamja/tiggle/user/adapter/in/web/request/DuplicatedEmailRequest.java
+++ b/src/main/java/com/gamja/tiggle/user/adapter/in/web/request/DuplicatedEmailRequest.java
@@ -1,0 +1,14 @@
+package com.gamja.tiggle.user.adapter.in.web.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DuplicatedEmailRequest {
+    private String email;
+}

--- a/src/main/java/com/gamja/tiggle/user/adapter/out/persistence/JpaUserRepository.java
+++ b/src/main/java/com/gamja/tiggle/user/adapter/out/persistence/JpaUserRepository.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 
 public interface JpaUserRepository extends JpaRepository<UserEntity, Long> {
     UserEntity findByEmail(String email);
+
+    Boolean existsByEmail(String email);
 }

--- a/src/main/java/com/gamja/tiggle/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/com/gamja/tiggle/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -97,5 +97,10 @@ public class UserPersistenceAdapter implements UserPersistencePort {
             throw new BaseException(BaseResponseStatus.NOT_FOUND_USER);
         }
     }
+
+    @Override
+    public Boolean existEmail(String email) {
+        return jpaUserRepository.existsByEmail(email);
+    }
 }
 

--- a/src/main/java/com/gamja/tiggle/user/application/port/in/DuplicatedEmailCommand.java
+++ b/src/main/java/com/gamja/tiggle/user/application/port/in/DuplicatedEmailCommand.java
@@ -1,0 +1,11 @@
+package com.gamja.tiggle.user.application.port.in;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DuplicatedEmailCommand {
+
+    private String email;
+}

--- a/src/main/java/com/gamja/tiggle/user/application/port/in/SignupUserUseCase.java
+++ b/src/main/java/com/gamja/tiggle/user/application/port/in/SignupUserUseCase.java
@@ -4,4 +4,6 @@ import com.gamja.tiggle.common.BaseException;
 
 public interface SignupUserUseCase {
     String signup(SignupUserCommand command) throws BaseException;
+
+    Boolean duplicatedEmail(DuplicatedEmailCommand command);
 }

--- a/src/main/java/com/gamja/tiggle/user/application/port/out/UserPersistencePort.java
+++ b/src/main/java/com/gamja/tiggle/user/application/port/out/UserPersistencePort.java
@@ -16,5 +16,7 @@ public interface UserPersistencePort {
     void savePoint(Long id, Integer point) throws BaseException;
 
     void existUser(Long id) throws BaseException;
+
+    Boolean existEmail(String email);
 }
 

--- a/src/main/java/com/gamja/tiggle/user/application/service/SignupUserService.java
+++ b/src/main/java/com/gamja/tiggle/user/application/service/SignupUserService.java
@@ -1,6 +1,8 @@
 package com.gamja.tiggle.user.application.service;
 
 import com.gamja.tiggle.common.BaseException;
+import com.gamja.tiggle.common.BaseResponseStatus;
+import com.gamja.tiggle.user.application.port.in.DuplicatedEmailCommand;
 import com.gamja.tiggle.user.application.port.in.SignupUserCommand;
 import com.gamja.tiggle.user.application.port.in.SignupUserUseCase;
 import com.gamja.tiggle.user.application.port.out.EmailVerifyPort;
@@ -19,6 +21,11 @@ public class SignupUserService implements SignupUserUseCase {
 
     @Override
     public String signup(SignupUserCommand command) throws BaseException {
+
+        if (userPersistencePort.existEmail(command.getEmail())) {
+            throw new BaseException(BaseResponseStatus.EXISTED_EMAIL);
+        }
+
         User user = User.builder()
                 .name(command.getName())
                 .email(command.getEmail())
@@ -36,5 +43,10 @@ public class SignupUserService implements SignupUserUseCase {
         emailVerifyPort.saveVerify(user.getEmail(), uuid);
 
         return uuid;
+    }
+
+    @Override
+    public Boolean duplicatedEmail(DuplicatedEmailCommand command) {
+        return userPersistencePort.existEmail(command.getEmail());
     }
 }


### PR DESCRIPTION
## 연관된 이슈
#162
<br>

## 작업 내용
회원가입 이메일 입력 시 클릭마다 이메일 중복 체크를 하도록 하기 위한 메서드
프론트에서 이메일 중복 처리는 되나 모든 입력에서 DuplicatedEmail api를 호출하는 문제가 발생해서 
해결중에 있습니다. 



<br> 

## 전달 사항
